### PR TITLE
Break down OTP service and rewrite it with exchange service.

### DIFF
--- a/rest/src/main/resources/application.json
+++ b/rest/src/main/resources/application.json
@@ -17,10 +17,18 @@
       "allowed": [
         {
           "from": "basic",
+          "to": "otp"
+        },
+        {
+          "from": "basic",
           "to": "accessToken"
         },
         {
           "from": "refresh",
+          "to": "accessToken"
+        },
+        {
+          "from": "otp",
           "to": "accessToken"
         }
       ]

--- a/service/src/main/java/com/authguard/service/OtpService.java
+++ b/service/src/main/java/com/authguard/service/OtpService.java
@@ -1,10 +1,7 @@
 package com.authguard.service;
 
-import com.authguard.service.model.AccountBO;
 import com.authguard.service.model.TokensBO;
 
 public interface OtpService {
-    TokensBO generate(AccountBO account);
-
     TokensBO authenticate(String passwordId, String otp);
 }

--- a/service/src/main/java/com/authguard/service/exchange/BasicToAccessToken.java
+++ b/service/src/main/java/com/authguard/service/exchange/BasicToAccessToken.java
@@ -19,7 +19,7 @@ public class BasicToAccessToken implements Exchange {
     }
 
     @Override
-    public Optional<TokensBO> exchangeToken(String basicToken) {
+    public Optional<TokensBO> exchangeToken(final String basicToken) {
         return basicAuth.authenticateAndGetAccount(basicToken)
                 .map(accessTokenProvider::generateToken);
     }

--- a/service/src/main/java/com/authguard/service/exchange/BasicToOtp.java
+++ b/service/src/main/java/com/authguard/service/exchange/BasicToOtp.java
@@ -1,8 +1,8 @@
 package com.authguard.service.exchange;
 
-import com.authguard.service.OtpService;
 import com.authguard.service.exchange.helpers.BasicAuth;
 import com.authguard.service.model.TokensBO;
+import com.authguard.service.otp.OtpProvider;
 import com.google.inject.Inject;
 
 import java.util.Optional;
@@ -10,17 +10,17 @@ import java.util.Optional;
 @TokenExchange(from = "basic", to = "otp")
 public class BasicToOtp implements Exchange {
     private final BasicAuth basicAuth;
-    private final OtpService otpService;
+    private final OtpProvider otpProvider;
 
     @Inject
-    public BasicToOtp(final BasicAuth basicAuth, final OtpService otpService) {
+    public BasicToOtp(final BasicAuth basicAuth, final OtpProvider otpProvider) {
         this.basicAuth = basicAuth;
-        this.otpService = otpService;
+        this.otpProvider = otpProvider;
     }
 
     @Override
     public Optional<TokensBO> exchangeToken(final String basicToken) {
         return basicAuth.authenticateAndGetAccount(basicToken)
-                .map(otpService::generate);
+                .map(otpProvider::generateToken);
     }
 }

--- a/service/src/main/java/com/authguard/service/exchange/OtpToAccessToken.java
+++ b/service/src/main/java/com/authguard/service/exchange/OtpToAccessToken.java
@@ -1,0 +1,31 @@
+package com.authguard.service.exchange;
+
+import com.authguard.service.AccountsService;
+import com.authguard.service.jwt.AccessTokenProvider;
+import com.authguard.service.model.TokensBO;
+import com.authguard.service.otp.OtpVerifier;
+import com.google.inject.Inject;
+
+import java.util.Optional;
+
+@TokenExchange(from = "otp", to = "accessToken")
+public class OtpToAccessToken implements Exchange {
+    private final AccountsService accountsService;
+    private final OtpVerifier otpVerifier;
+    private final AccessTokenProvider accessTokenProvider;
+
+    @Inject
+    public OtpToAccessToken(final AccountsService accountsService, final OtpVerifier otpVerifier,
+                            final AccessTokenProvider accessTokenProvider) {
+        this.accountsService = accountsService;
+        this.otpVerifier = otpVerifier;
+        this.accessTokenProvider = accessTokenProvider;
+    }
+
+    @Override
+    public Optional<TokensBO> exchangeToken(final String otpToken) {
+        return otpVerifier.verifyAccountToken(otpToken)
+                .flatMap(accountsService::getById)
+                .map(accessTokenProvider::generateToken);
+    }
+}

--- a/service/src/main/java/com/authguard/service/impl/OtpServiceImpl.java
+++ b/service/src/main/java/com/authguard/service/impl/OtpServiceImpl.java
@@ -2,110 +2,27 @@ package com.authguard.service.impl;
 
 import com.authguard.config.ConfigContext;
 import com.authguard.service.ExchangeService;
-import com.authguard.service.config.ConfigParser;
 import com.authguard.service.config.OtpConfig;
-import com.authguard.service.mappers.ServiceMapper;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import org.apache.commons.lang3.RandomStringUtils;
-import com.authguard.dal.OtpRepository;
-import com.authguard.emb.MessagePublisher;
-import com.authguard.emb.model.EventType;
-import com.authguard.emb.model.MessageMO;
-import com.authguard.service.AccountsService;
 import com.authguard.service.OtpService;
-import com.authguard.service.exceptions.ServiceAuthorizationException;
-import com.authguard.service.model.AccountBO;
-import com.authguard.service.model.OneTimePasswordBO;
 import com.authguard.service.model.TokensBO;
 
-import java.time.OffsetDateTime;
-import java.time.ZonedDateTime;
-import java.util.UUID;
-
 public class OtpServiceImpl implements OtpService {
-    private final OtpRepository otpRepository;
-    private final MessagePublisher emb;
-    private final AccountsService accountsService;
-    private final ServiceMapper serviceMapper;
     private final ExchangeService exchangeService;
     private final OtpConfig otpConfig;
 
     @Inject
-    public OtpServiceImpl(final OtpRepository otpRepository, final MessagePublisher emb,
-                          final AccountsService accountsService,
-                          final ExchangeService exchangeService,
-                          final ServiceMapper serviceMapper,
+    public OtpServiceImpl(final ExchangeService exchangeService,
                           @Named("otp") final ConfigContext configContext) {
-        this.otpRepository = otpRepository;
-        this.emb = emb;
-        this.accountsService = accountsService;
-        this.serviceMapper = serviceMapper;
         this.exchangeService = exchangeService;
         this.otpConfig = configContext.asConfigBean(OtpConfig.class);
     }
 
     @Override
-    public TokensBO generate(final AccountBO account) {
-        final String passwordId = UUID.randomUUID().toString();
-        final String password = generatePassword();
-
-        final TokensBO token = createToken(passwordId);
-
-        final OneTimePasswordBO oneTimePassword = OneTimePasswordBO.builder()
-                .id(passwordId)
-                .accountId(account.getId())
-                .expiresAt(ZonedDateTime.now().plus(ConfigParser.parseDuration(otpConfig.getLifeTime())))
-                .password(password)
-                .build();
-
-        otpRepository.save(serviceMapper.toDO(oneTimePassword));
-
-        // a place holder until actual implementation is available
-        emb.publish(MessageMO.builder()
-                .eventType(EventType.OTP)
-                .timestamp(OffsetDateTime.now())
-                .messageBody(oneTimePassword)
-                .build());
-
-        return token;
-    }
-
-    @Override
     public TokensBO authenticate(final String passwordId, final String otp) {
-        final OneTimePasswordBO generated = otpRepository.getById(passwordId)
-                .thenApply(optional -> optional.map(serviceMapper::toBO))
-                .join()
-                .orElseThrow(() -> new ServiceAuthorizationException("Invalid OTP ID"));
+        final String token = passwordId + ":" + otp;
 
-        if (generated.getExpiresAt().isBefore(ZonedDateTime.now())) {
-            throw new ServiceAuthorizationException("OTP " + passwordId + " has expired");
-        }
-
-        if (generated.getPassword().equals(otp)) {
-            return accountsService.getById(generated.getAccountId())
-                    // TODO temporary until we have a proper exchange for OTPs
-                    .map(account -> exchangeService.exchange(passwordId + ":" + otp, "otp", "accessToken"))
-                    .orElseThrow(() -> new ServiceAuthorizationException("Account " + generated.getAccountId()
-                            + " doesn't exist"));
-        } else {
-            throw new ServiceAuthorizationException("OTPs don't match");
-        }
-    }
-
-    private TokensBO createToken(final String passwordId) {
-        return TokensBO.builder()
-                .type("OTP")
-                .token(passwordId)
-                .build();
-    }
-
-    private String generatePassword() {
-        switch (otpConfig.getMode()) {
-            case ALPHANUMERIC: return RandomStringUtils.randomAlphanumeric(otpConfig.getLength());
-            case ALPHABETIC: return RandomStringUtils.randomAlphabetic(otpConfig.getLength());
-            case NUMERIC: return RandomStringUtils.randomNumeric(otpConfig.getLength());
-            default: throw new IllegalStateException("Unrecognized OTP mode " + otpConfig.getMode());
-        }
+        return exchangeService.exchange(token, "otp", otpConfig.getGenerateToken());
     }
 }

--- a/service/src/main/java/com/authguard/service/otp/OtpProvider.java
+++ b/service/src/main/java/com/authguard/service/otp/OtpProvider.java
@@ -1,0 +1,72 @@
+package com.authguard.service.otp;
+
+import com.authguard.config.ConfigContext;
+import com.authguard.dal.OtpRepository;
+import com.authguard.service.AuthProvider;
+import com.authguard.service.config.ConfigParser;
+import com.authguard.service.config.OtpConfig;
+import com.authguard.service.mappers.ServiceMapper;
+import com.authguard.service.model.AccountBO;
+import com.authguard.service.model.AppBO;
+import com.authguard.service.model.OneTimePasswordBO;
+import com.authguard.service.model.TokensBO;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+public class OtpProvider implements AuthProvider {
+    private final OtpRepository otpRepository;
+    private final ServiceMapper serviceMapper;
+    private final OtpConfig otpConfig;
+
+    @Inject
+    public OtpProvider(final OtpRepository otpRepository, final ServiceMapper serviceMapper,
+                       final @Named("otp") ConfigContext otpConfig) {
+        this.otpRepository = otpRepository;
+        this.serviceMapper = serviceMapper;
+        this.otpConfig = otpConfig.asConfigBean(OtpConfig.class);
+    }
+
+    @Override
+    public TokensBO generateToken(final AccountBO account) {
+        final String passwordId = UUID.randomUUID().toString();
+        final String password = generatePassword();
+
+        final TokensBO token = createToken(passwordId);
+
+        final OneTimePasswordBO oneTimePassword = OneTimePasswordBO.builder()
+                .id(passwordId)
+                .accountId(account.getId())
+                .expiresAt(ZonedDateTime.now().plus(ConfigParser.parseDuration(otpConfig.getLifeTime())))
+                .password(password)
+                .build();
+
+        otpRepository.save(serviceMapper.toDO(oneTimePassword));
+
+        return token;
+    }
+
+    @Override
+    public TokensBO generateToken(final AppBO app) {
+        throw new UnsupportedOperationException("OTPs cannot be generated for applications");
+    }
+
+    private TokensBO createToken(final String passwordId) {
+        return TokensBO.builder()
+                .type("OTP")
+                .token(passwordId)
+                .build();
+    }
+
+    private String generatePassword() {
+        switch (otpConfig.getMode()) {
+            case ALPHANUMERIC: return RandomStringUtils.randomAlphanumeric(otpConfig.getLength());
+            case ALPHABETIC: return RandomStringUtils.randomAlphabetic(otpConfig.getLength());
+            case NUMERIC: return RandomStringUtils.randomNumeric(otpConfig.getLength());
+            default: throw new IllegalStateException("Unrecognized OTP mode " + otpConfig.getMode());
+        }
+    }
+}

--- a/service/src/main/java/com/authguard/service/otp/OtpVerifier.java
+++ b/service/src/main/java/com/authguard/service/otp/OtpVerifier.java
@@ -1,0 +1,49 @@
+package com.authguard.service.otp;
+
+import com.authguard.dal.OtpRepository;
+import com.authguard.service.AuthTokenVerfier;
+import com.authguard.service.exceptions.ServiceAuthorizationException;
+import com.authguard.service.mappers.ServiceMapper;
+import com.authguard.service.model.OneTimePasswordBO;
+import com.google.inject.Inject;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+public class OtpVerifier implements AuthTokenVerfier {
+    private final OtpRepository otpRepository;
+    private final ServiceMapper serviceMapper;
+
+    @Inject
+    public OtpVerifier(final OtpRepository otpRepository, final ServiceMapper serviceMapper) {
+        this.otpRepository = otpRepository;
+        this.serviceMapper = serviceMapper;
+    }
+
+    @Override
+    public Optional<String> verifyAccountToken(final String token) {
+        final String[] parts = token.split(":");
+
+        if (parts.length != 2) {
+            throw new ServiceAuthorizationException("Invalid OTP token format");
+        }
+
+        final String passwordId = parts[0];
+        final String otp = parts[1];
+
+        final OneTimePasswordBO generated = otpRepository.getById(passwordId)
+                .thenApply(optional -> optional.map(serviceMapper::toBO))
+                .join()
+                .orElseThrow(() -> new ServiceAuthorizationException("Invalid OTP ID"));
+
+        if (generated.getExpiresAt().isBefore(ZonedDateTime.now())) {
+            throw new ServiceAuthorizationException("OTP " + passwordId + " has expired");
+        }
+
+        if (generated.getPassword().equals(otp)) {
+            return Optional.of(generated.getAccountId());
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/service/src/test/java/com/authguard/service/impl/OtpServiceImplTest.java
+++ b/service/src/test/java/com/authguard/service/impl/OtpServiceImplTest.java
@@ -1,247 +1,52 @@
 package com.authguard.service.impl;
 
 import com.authguard.config.ConfigContext;
-import com.authguard.dal.OtpRepository;
-import com.authguard.service.AccountsService;
 import com.authguard.service.ExchangeService;
 import com.authguard.service.config.OtpConfig;
-import com.authguard.service.config.OtpMode;
 import com.authguard.dal.model.OneTimePasswordDO;
-import com.authguard.emb.MessagePublisher;
-import com.authguard.service.exceptions.ServiceAuthorizationException;
-import com.authguard.service.mappers.ServiceMapperImpl;
-import com.authguard.service.model.AccountBO;
 import com.authguard.service.model.TokensBO;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.time.Duration;
-import java.time.ZonedDateTime;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 
 class OtpServiceImplTest {
     private final EasyRandom random = new EasyRandom(new EasyRandomParameters().collectionSizeRange(1, 4));
 
-    private OtpRepository mockOtpRepository;
-    private AccountsService mockAccountsService;
     private ExchangeService mockExchangeService;
-    private MessagePublisher mockMessagePublisher;
 
     private OtpServiceImpl otpService;
 
     void setup(final OtpConfig otpConfig) {
-        mockOtpRepository = Mockito.mock(OtpRepository.class);
-        mockAccountsService = Mockito.mock(AccountsService.class);
         mockExchangeService = Mockito.mock(ExchangeService.class);
-        mockMessagePublisher = Mockito.mock(MessagePublisher.class);
 
         final ConfigContext configContext = Mockito.mock(ConfigContext.class);
 
         Mockito.when(configContext.asConfigBean(OtpConfig.class)).thenReturn(otpConfig);
 
-        otpService = new OtpServiceImpl(mockOtpRepository, mockMessagePublisher,
-                mockAccountsService, mockExchangeService, new ServiceMapperImpl(), configContext);
-    }
-
-    @Test
-    void generateAlphanumeric() {
-        final OtpConfig otpConfig = OtpConfig.builder()
-                .mode(OtpMode.ALPHANUMERIC)
-                .length(6)
-                .lifeTime("5m")
-                .build();
-
-        setup(otpConfig);
-
-        final AccountBO account = random.nextObject(AccountBO.class);
-
-        final TokensBO generated = otpService.generate(account);
-
-        assertThat(generated.getType()).isEqualTo("OTP");
-        assertThat(generated.getToken()).isNotNull();
-        assertThat(generated.getRefreshToken()).isNull();
-
-        final ArgumentCaptor<OneTimePasswordDO> argumentCaptor = ArgumentCaptor.forClass(OneTimePasswordDO.class);
-
-        Mockito.verify(mockOtpRepository).save(argumentCaptor.capture());
-        Mockito.verify(mockMessagePublisher).publish(any());
-
-        final OneTimePasswordDO persisted = argumentCaptor.getValue();
-
-        assertThat(persisted.getAccountId()).isEqualTo(account.getId());
-        assertThat(persisted.getExpiresAt())
-                .isAfter(ZonedDateTime.now())
-                .isBefore(ZonedDateTime.now().plus(Duration.ofMinutes(6)));
-        assertThat(persisted.getId()).isNotNull();
-        assertThat(persisted.getPassword()).isNotNull();
-        assertThat(persisted.getPassword()).hasSize(6);
-    }
-
-    @Test
-    void generateAlphabetic() {
-        final OtpConfig otpConfig = OtpConfig.builder()
-                .mode(OtpMode.ALPHABETIC)
-                .length(6)
-                .lifeTime("5m")
-                .build();
-
-        setup(otpConfig);
-
-        final AccountBO account = random.nextObject(AccountBO.class);
-
-        final TokensBO generated = otpService.generate(account);
-
-        assertThat(generated.getType()).isEqualTo("OTP");
-        assertThat(generated.getToken()).isNotNull();
-        assertThat(generated.getRefreshToken()).isNull();
-
-        final ArgumentCaptor<OneTimePasswordDO> argumentCaptor = ArgumentCaptor.forClass(OneTimePasswordDO.class);
-
-        Mockito.verify(mockOtpRepository).save(argumentCaptor.capture());
-        Mockito.verify(mockMessagePublisher).publish(any());
-
-        final OneTimePasswordDO persisted = argumentCaptor.getValue();
-
-        assertThat(persisted.getAccountId()).isEqualTo(account.getId());
-        assertThat(persisted.getExpiresAt())
-                .isAfter(ZonedDateTime.now())
-                .isBefore(ZonedDateTime.now().plus(Duration.ofMinutes(6)));
-        assertThat(persisted.getId()).isNotNull();
-        assertThat(persisted.getPassword()).isNotNull();
-        assertThat(persisted.getPassword()).hasSize(6);
-
-        for (final char ch : persisted.getPassword().toCharArray()) {
-            assertThat(Character.isDigit(ch)).isFalse();
-        }
-    }
-
-    @Test
-    void generateNumeric() {
-        final OtpConfig otpConfig = OtpConfig.builder()
-                .mode(OtpMode.NUMERIC)
-                .length(6)
-                .lifeTime("5m")
-                .build();
-
-        setup(otpConfig);
-
-        final AccountBO account = random.nextObject(AccountBO.class);
-
-        final TokensBO generated = otpService.generate(account);
-
-        assertThat(generated.getType()).isEqualTo("OTP");
-        assertThat(generated.getToken()).isNotNull();
-        assertThat(generated.getRefreshToken()).isNull();
-
-        final ArgumentCaptor<OneTimePasswordDO> argumentCaptor = ArgumentCaptor.forClass(OneTimePasswordDO.class);
-
-        Mockito.verify(mockOtpRepository).save(argumentCaptor.capture());
-        Mockito.verify(mockMessagePublisher).publish(any());
-
-        final OneTimePasswordDO persisted = argumentCaptor.getValue();
-
-        assertThat(persisted.getAccountId()).isEqualTo(account.getId());
-        assertThat(persisted.getExpiresAt())
-                .isAfter(ZonedDateTime.now())
-                .isBefore(ZonedDateTime.now().plus(Duration.ofMinutes(6)));
-        assertThat(persisted.getId()).isNotNull();
-        assertThat(persisted.getPassword()).isNotNull();
-        assertThat(persisted.getPassword()).hasSize(6);
-
-        for (final char ch : persisted.getPassword().toCharArray()) {
-            assertThat(Character.isAlphabetic(ch)).isFalse();
-        }
+        otpService = new OtpServiceImpl(mockExchangeService, configContext);
     }
 
     @Test
     void authenticate() {
         final OtpConfig otpConfig = OtpConfig.builder()
-                .mode(OtpMode.ALPHANUMERIC)
-                .length(6)
-                .lifeTime("5m")
+                .generateToken("accessToken")
                 .build();
 
         setup(otpConfig);
 
         final OneTimePasswordDO otp = random.nextObject(OneTimePasswordDO.class);
-        final AccountBO account = random.nextObject(AccountBO.class)
-                .withId(otp.getAccountId());
         final TokensBO tokens = random.nextObject(TokensBO.class);
 
-        Mockito.when(mockOtpRepository.getById(otp.getId())).thenReturn(CompletableFuture.completedFuture(Optional.of(otp)));
-        Mockito.when(mockAccountsService.getById(account.getId())).thenReturn(Optional.of(account));
-        Mockito.when(mockExchangeService.exchange(any(), any(), any())).thenReturn(tokens);
+        final String otpToken = otp.getId() + ":" + otp.getPassword();
+
+        Mockito.when(mockExchangeService.exchange(otpToken, "otp", otpConfig.getGenerateToken()))
+                .thenReturn(tokens);
 
         final TokensBO generated = otpService.authenticate(otp.getId(), otp.getPassword());
 
         assertThat(generated).isEqualTo(tokens);
-    }
-
-    @Test
-    void authenticateWrongPassword() {
-        final OtpConfig otpConfig = OtpConfig.builder()
-                .mode(OtpMode.ALPHANUMERIC)
-                .length(6)
-                .lifeTime("5m")
-                .build();
-
-        setup(otpConfig);
-
-        final OneTimePasswordDO otp = random.nextObject(OneTimePasswordDO.class);
-        final AccountBO account = random.nextObject(AccountBO.class)
-                .withId(otp.getAccountId());
-        final TokensBO tokens = random.nextObject(TokensBO.class);
-
-        Mockito.when(mockOtpRepository.getById(otp.getId())).thenReturn(CompletableFuture.completedFuture(Optional.of(otp)));
-        Mockito.when(mockAccountsService.getById(account.getId())).thenReturn(Optional.of(account));
-        Mockito.when(mockExchangeService.exchange(any(), any(), any())).thenReturn(tokens);
-
-        assertThatThrownBy(() -> otpService.authenticate(otp.getId(), "wrong"))
-                .isInstanceOf(ServiceAuthorizationException.class);
-    }
-
-    @Test
-    void authenticateAccountNotFound() {
-        final OtpConfig otpConfig = OtpConfig.builder()
-                .mode(OtpMode.ALPHANUMERIC)
-                .length(6)
-                .lifeTime("5m")
-                .build();
-
-        setup(otpConfig);
-
-        final OneTimePasswordDO otp = random.nextObject(OneTimePasswordDO.class);
-
-        Mockito.when(mockOtpRepository.getById(otp.getId())).thenReturn(CompletableFuture.completedFuture(Optional.of(otp)));
-        Mockito.when(mockAccountsService.getById(otp.getAccountId())).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> otpService.authenticate(otp.getId(), otp.getPassword()))
-                .isInstanceOf(ServiceAuthorizationException.class);
-    }
-
-    @Test
-    void authenticatePasswordNotFound() {
-        final OtpConfig otpConfig = OtpConfig.builder()
-                .mode(OtpMode.ALPHANUMERIC)
-                .length(6)
-                .lifeTime("5m")
-                .build();
-
-        setup(otpConfig);
-
-        final OneTimePasswordDO otp = random.nextObject(OneTimePasswordDO.class);
-
-        Mockito.when(mockOtpRepository.getById(otp.getId())).thenReturn(CompletableFuture.completedFuture(Optional.empty()));
-
-        assertThatThrownBy(() -> otpService.authenticate(otp.getId(), otp.getPassword()))
-                .isInstanceOf(ServiceAuthorizationException.class);
     }
 }

--- a/service/src/test/java/com/authguard/service/otp/OtpProviderTest.java
+++ b/service/src/test/java/com/authguard/service/otp/OtpProviderTest.java
@@ -1,0 +1,145 @@
+package com.authguard.service.otp;
+
+import com.authguard.config.ConfigContext;
+import com.authguard.dal.OtpRepository;
+import com.authguard.dal.model.OneTimePasswordDO;
+import com.authguard.service.config.OtpConfig;
+import com.authguard.service.config.OtpMode;
+import com.authguard.service.mappers.ServiceMapperImpl;
+import com.authguard.service.model.AccountBO;
+import com.authguard.service.model.TokensBO;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtpProviderTest {
+    private final EasyRandom random = new EasyRandom(new EasyRandomParameters().collectionSizeRange(1, 4));
+
+    private OtpRepository mockOtpRepository;
+
+    private OtpProvider otpProvider;
+
+    void setup(final OtpConfig otpConfig) {
+        mockOtpRepository = Mockito.mock(OtpRepository.class);
+
+        final ConfigContext configContext = Mockito.mock(ConfigContext.class);
+
+        Mockito.when(configContext.asConfigBean(OtpConfig.class)).thenReturn(otpConfig);
+
+        otpProvider = new OtpProvider(mockOtpRepository, new ServiceMapperImpl(), configContext);
+    }
+
+    @Test
+    void generateToken() {
+        final OtpConfig otpConfig = OtpConfig.builder()
+                .mode(OtpMode.ALPHANUMERIC)
+                .length(6)
+                .lifeTime("5m")
+                .build();
+
+        setup(otpConfig);
+
+        final AccountBO account = random.nextObject(AccountBO.class);
+
+        final TokensBO generated = otpProvider.generateToken(account);
+
+        assertThat(generated.getType()).isEqualTo("OTP");
+        assertThat(generated.getToken()).isNotNull();
+        assertThat(generated.getRefreshToken()).isNull();
+
+        final ArgumentCaptor<OneTimePasswordDO> argumentCaptor = ArgumentCaptor.forClass(OneTimePasswordDO.class);
+
+        Mockito.verify(mockOtpRepository).save(argumentCaptor.capture());
+
+        final OneTimePasswordDO persisted = argumentCaptor.getValue();
+
+        assertThat(persisted.getAccountId()).isEqualTo(account.getId());
+        assertThat(persisted.getExpiresAt())
+                .isAfter(ZonedDateTime.now())
+                .isBefore(ZonedDateTime.now().plus(Duration.ofMinutes(6)));
+        assertThat(persisted.getId()).isNotNull();
+        assertThat(persisted.getPassword()).isNotNull();
+        assertThat(persisted.getPassword()).hasSize(6);
+    }
+
+    @Test
+    void generateAlphabetic() {
+        final OtpConfig otpConfig = OtpConfig.builder()
+                .mode(OtpMode.ALPHABETIC)
+                .length(6)
+                .lifeTime("5m")
+                .build();
+
+        setup(otpConfig);
+
+        final AccountBO account = random.nextObject(AccountBO.class);
+
+        final TokensBO generated = otpProvider.generateToken(account);
+
+        assertThat(generated.getType()).isEqualTo("OTP");
+        assertThat(generated.getToken()).isNotNull();
+        assertThat(generated.getRefreshToken()).isNull();
+
+        final ArgumentCaptor<OneTimePasswordDO> argumentCaptor = ArgumentCaptor.forClass(OneTimePasswordDO.class);
+
+        Mockito.verify(mockOtpRepository).save(argumentCaptor.capture());
+
+        final OneTimePasswordDO persisted = argumentCaptor.getValue();
+
+        assertThat(persisted.getAccountId()).isEqualTo(account.getId());
+        assertThat(persisted.getExpiresAt())
+                .isAfter(ZonedDateTime.now())
+                .isBefore(ZonedDateTime.now().plus(Duration.ofMinutes(6)));
+        assertThat(persisted.getId()).isNotNull();
+        assertThat(persisted.getPassword()).isNotNull();
+        assertThat(persisted.getPassword()).hasSize(6);
+
+        for (final char ch : persisted.getPassword().toCharArray()) {
+            assertThat(Character.isDigit(ch)).isFalse();
+        }
+    }
+
+    @Test
+    void generateNumeric() {
+        final OtpConfig otpConfig = OtpConfig.builder()
+                .mode(OtpMode.NUMERIC)
+                .length(6)
+                .lifeTime("5m")
+                .build();
+
+        setup(otpConfig);
+
+        final AccountBO account = random.nextObject(AccountBO.class);
+
+        final TokensBO generated = otpProvider.generateToken(account);
+
+        assertThat(generated.getType()).isEqualTo("OTP");
+        assertThat(generated.getToken()).isNotNull();
+        assertThat(generated.getRefreshToken()).isNull();
+
+        final ArgumentCaptor<OneTimePasswordDO> argumentCaptor = ArgumentCaptor.forClass(OneTimePasswordDO.class);
+
+        Mockito.verify(mockOtpRepository).save(argumentCaptor.capture());
+
+        final OneTimePasswordDO persisted = argumentCaptor.getValue();
+
+        assertThat(persisted.getAccountId()).isEqualTo(account.getId());
+        assertThat(persisted.getExpiresAt())
+                .isAfter(ZonedDateTime.now())
+                .isBefore(ZonedDateTime.now().plus(Duration.ofMinutes(6)));
+        assertThat(persisted.getId()).isNotNull();
+        assertThat(persisted.getPassword()).isNotNull();
+        assertThat(persisted.getPassword()).hasSize(6);
+
+        for (final char ch : persisted.getPassword().toCharArray()) {
+            assertThat(Character.isAlphabetic(ch)).isFalse();
+        }
+    }
+}

--- a/service/src/test/java/com/authguard/service/otp/OtpVerifierTest.java
+++ b/service/src/test/java/com/authguard/service/otp/OtpVerifierTest.java
@@ -1,0 +1,109 @@
+package com.authguard.service.otp;
+
+import com.authguard.config.ConfigContext;
+import com.authguard.dal.OtpRepository;
+import com.authguard.dal.model.OneTimePasswordDO;
+import com.authguard.service.config.OtpConfig;
+import com.authguard.service.config.OtpMode;
+import com.authguard.service.exceptions.ServiceAuthorizationException;
+import com.authguard.service.mappers.ServiceMapperImpl;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OtpVerifierTest {
+
+    private final EasyRandom random = new EasyRandom(new EasyRandomParameters().collectionSizeRange(1, 4));
+
+    private OtpRepository mockOtpRepository;
+
+    private OtpVerifier otpVerifier;
+
+    void setup(final OtpConfig otpConfig) {
+        mockOtpRepository = Mockito.mock(OtpRepository.class);
+
+        final ConfigContext configContext = Mockito.mock(ConfigContext.class);
+
+        Mockito.when(configContext.asConfigBean(OtpConfig.class)).thenReturn(otpConfig);
+
+        otpVerifier = new OtpVerifier(mockOtpRepository, new ServiceMapperImpl());
+    }
+
+    @Test
+    void verify() {
+        final OtpConfig otpConfig = OtpConfig.builder()
+                .mode(OtpMode.ALPHANUMERIC)
+                .length(6)
+                .lifeTime("5m")
+                .build();
+
+        setup(otpConfig);
+
+        final OneTimePasswordDO otp = random.nextObject(OneTimePasswordDO.class);
+
+        Mockito.when(mockOtpRepository.getById(otp.getId()))
+                .thenReturn(CompletableFuture.completedFuture(Optional.of(otp)));
+
+        final Optional<String> generated = otpVerifier.verifyAccountToken(otp.getId() + ":" + otp.getPassword());
+
+        assertThat(generated).contains(otp.getAccountId());
+    }
+
+    @Test
+    void verifyWrongPassword() {
+        final OtpConfig otpConfig = OtpConfig.builder()
+                .mode(OtpMode.ALPHANUMERIC)
+                .length(6)
+                .lifeTime("5m")
+                .build();
+
+        setup(otpConfig);
+
+        final OneTimePasswordDO otp = random.nextObject(OneTimePasswordDO.class);
+
+        Mockito.when(mockOtpRepository.getById(otp.getId()))
+                .thenReturn(CompletableFuture.completedFuture(Optional.of(otp)));
+
+        assertThat(otpVerifier.verifyAccountToken(otp.getId() + ":" + "wrong")).isEmpty();
+    }
+
+    @Test
+    void verifyInvalidOtpFormat() {
+        final OtpConfig otpConfig = OtpConfig.builder()
+                .mode(OtpMode.ALPHANUMERIC)
+                .length(6)
+                .lifeTime("5m")
+                .build();
+
+        setup(otpConfig);
+
+        assertThatThrownBy(() -> otpVerifier.verifyAccountToken("not a valid OTP"))
+                .isInstanceOf(ServiceAuthorizationException.class);
+    }
+
+    @Test
+    void verifyPasswordNotFound() {
+        final OtpConfig otpConfig = OtpConfig.builder()
+                .mode(OtpMode.ALPHANUMERIC)
+                .length(6)
+                .lifeTime("5m")
+                .build();
+
+        setup(otpConfig);
+
+        final OneTimePasswordDO otp = random.nextObject(OneTimePasswordDO.class);
+
+        Mockito.when(mockOtpRepository.getById(otp.getId()))
+                .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
+
+        assertThatThrownBy(() -> otpVerifier.verifyAccountToken(otp.getId() + ":" + otp.getPassword()))
+                .isInstanceOf(ServiceAuthorizationException.class);
+    }
+}


### PR DESCRIPTION
OTP was broken down into OtpProvider and OtpVerifier, and a new exchange to convert OTP to access token was created. The whole service was rewritten to use that exchange through the exchange service.