### PR TITLE
Password versioning

### DIFF
--- a/api/src/main/java/com/nexblocks/authguard/api/dto/entities/Credentials.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/entities/Credentials.java
@@ -18,4 +18,5 @@ public interface Credentials {
     String getAccountId();
     List<UserIdentifierDTO> getIdentifiers();
     String getPlainPassword();
+    Integer getPasswordVersion();
 }

--- a/basic-auth/src/main/java/com/nexblocks/authguard/basic/BasicAuthProvider.java
+++ b/basic-auth/src/main/java/com/nexblocks/authguard/basic/BasicAuthProvider.java
@@ -1,5 +1,6 @@
 package com.nexblocks.authguard.basic;
 
+import com.google.inject.Inject;
 import com.nexblocks.authguard.basic.passwords.SecurePassword;
 import com.nexblocks.authguard.basic.passwords.SecurePasswordProvider;
 import com.nexblocks.authguard.service.AccountsService;
@@ -8,7 +9,6 @@ import com.nexblocks.authguard.service.exceptions.ServiceAuthorizationException;
 import com.nexblocks.authguard.service.exceptions.ServiceException;
 import com.nexblocks.authguard.service.exceptions.codes.ErrorCode;
 import com.nexblocks.authguard.service.model.*;
-import com.google.inject.Inject;
 import io.vavr.control.Either;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,30 +95,63 @@ public class BasicAuthProvider {
                 return Either.left(validationError.get());
             }
 
-            if (securePasswordProvider.passwordsExpire()) {
-                if (credentials.getPasswordUpdatedAt() == null) {
-                    return Either.left(new IllegalStateException("Credentials " + credentials.getId() + " passwordUpdatedAt was null"));
-                }
-
-                final OffsetDateTime expiresAt = credentials.getPasswordUpdatedAt()
-                        .plus(securePasswordProvider.getPasswordTtl());
-
-                if (expiresAt.isBefore(OffsetDateTime.now())) {
-                    return Either.left(new ServiceAuthorizationException(ErrorCode.PASSWORD_EXPIRED,
-                            "Password has already expired", EntityType.ACCOUNT, credentials.getAccountId()));
-                }
-            }
-
-            if (securePassword.verify(password, credentials.getHashedPassword())) {
-                return getAccountById(credentialsOpt.get().getAccountId());
-            } else {
-                return Either.left(new ServiceAuthorizationException(ErrorCode.PASSWORDS_DO_NOT_MATCH,
-                        "Passwords do not match", EntityType.ACCOUNT, credentials.getAccountId()));
-            }
+            return checkIfExpired(credentials)
+                    .flatMap(valid -> checkPasswordsMatch(valid, password))
+                    .flatMap(valid -> getAccountById(valid.getAccountId()));
         } else {
             return Either.left(new ServiceAuthorizationException(ErrorCode.CREDENTIALS_DOES_NOT_EXIST,
                     "Identifier " + username + " does not exist"));
         }
+    }
+
+    private Either<Exception, CredentialsBO> checkIfExpired(final CredentialsBO credentials) {
+        // check if expired
+        if (securePasswordProvider.passwordsExpire()) {
+            if (credentials.getPasswordUpdatedAt() == null) {
+                return Either.left(new IllegalStateException("Credentials " + credentials.getId() + " passwordUpdatedAt was null"));
+            }
+
+            final OffsetDateTime expiresAt = credentials.getPasswordUpdatedAt()
+                    .plus(securePasswordProvider.getPasswordTtl());
+
+            if (expiresAt.isBefore(OffsetDateTime.now())) {
+                return Either.left(new ServiceAuthorizationException(ErrorCode.PASSWORD_EXPIRED,
+                        "Password has already expired", EntityType.ACCOUNT, credentials.getAccountId()));
+            }
+        }
+
+        // check if the version is too old
+        if (credentials.getPasswordVersion() < securePasswordProvider.getMinimumVersion()) {
+            return Either.left(new ServiceAuthorizationException(ErrorCode.PASSWORD_EXPIRED,
+                    "Password has already expired", EntityType.ACCOUNT, credentials.getAccountId()));
+        }
+
+        return Either.right(credentials);
+    }
+
+    private Either<Exception, CredentialsBO> checkPasswordsMatch(final CredentialsBO credentials, final String password) {
+        final SecurePassword securePasswordImplementation = getPasswordImplementation(credentials);
+
+        if (securePasswordImplementation == null) {
+            return Either.left(new ServiceAuthorizationException(ErrorCode.GENERIC_AUTH_FAILURE,
+                    "Unable to map password version", EntityType.ACCOUNT, credentials.getAccountId()));
+        }
+
+        if (securePasswordImplementation.verify(password, credentials.getHashedPassword())) {
+            return Either.right(credentials);
+        } else {
+            return Either.left(new ServiceAuthorizationException(ErrorCode.PASSWORDS_DO_NOT_MATCH,
+                    "Passwords do not match", EntityType.ACCOUNT, credentials.getAccountId()));
+        }
+    }
+
+    private SecurePassword getPasswordImplementation(final CredentialsBO credentials) {
+        if (credentials.getPasswordVersion() == null
+                || credentials.getPasswordVersion().equals(securePasswordProvider.getCurrentVersion())) {
+            return securePassword;
+        }
+
+        return securePasswordProvider.getPreviousVersions().get(credentials.getPasswordVersion());
     }
 
     private Either<Exception, AccountBO> verifyCredentialsAndGetAccount(final String username) {

--- a/basic-auth/src/main/java/com/nexblocks/authguard/basic/config/PasswordConditionsInterface.java
+++ b/basic-auth/src/main/java/com/nexblocks/authguard/basic/config/PasswordConditionsInterface.java
@@ -19,7 +19,7 @@ public interface PasswordConditionsInterface {
 
     @Value.Default
     default int getMaxLength() {
-        return Integer.MAX_VALUE;
+        return 30;
     }
 
     @Value.Default

--- a/basic-auth/src/main/java/com/nexblocks/authguard/basic/config/PasswordsConfigInterface.java
+++ b/basic-auth/src/main/java/com/nexblocks/authguard/basic/config/PasswordsConfigInterface.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.nexblocks.authguard.service.config.ConfigStyle;
 import org.immutables.value.Value;
 
-import java.time.OffsetDateTime;
+import java.util.List;
 
 @Value.Immutable
 @ConfigStyle
@@ -28,4 +28,14 @@ public interface PasswordsConfigInterface {
     }
 
     String getValidFor();
+
+    @Value.Default
+    default Integer getMinimumVersion() { return 0; }
+
+    @Value.Default
+    default Integer getVersion() {
+        return 1;
+    }
+
+    List<PasswordsConfig> getPreviousVersions();
 }

--- a/basic-auth/src/main/java/com/nexblocks/authguard/basic/passwords/SecurePasswordProvider.java
+++ b/basic-auth/src/main/java/com/nexblocks/authguard/basic/passwords/SecurePasswordProvider.java
@@ -1,34 +1,32 @@
 package com.nexblocks.authguard.basic.passwords;
 
-import com.nexblocks.authguard.basic.config.PasswordsConfig;
-import com.nexblocks.authguard.config.ConfigContext;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import com.nexblocks.authguard.basic.config.PasswordsConfig;
+import com.nexblocks.authguard.config.ConfigContext;
 import com.nexblocks.authguard.service.config.ConfigParser;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class SecurePasswordProvider {
     private final SecurePassword securePassword;
     private final boolean expirePasswords;
     private final Duration passwordTtl;
+    private final Integer currentVersion;
+    private final Integer minimumVersion;
+
+    private Map<Integer, SecurePassword> previousVersions;
 
     @Inject
     public SecurePasswordProvider(final @Named("passwords") ConfigContext config) {
         final PasswordsConfig passwordsConfig = config.asConfigBean(PasswordsConfig.class);
 
-        switch (passwordsConfig.getAlgorithm()) {
-            case "scrypt":
-                this.securePassword = new SCryptPassword(passwordsConfig.getScrypt());
-                break;
-
-            case "bcrypt":
-                this.securePassword = new BCryptPassword(passwordsConfig.getBcrypt());
-                break;
-
-            default:
-                throw new IllegalStateException("Unsupported password algorithm " + passwordsConfig.getAlgorithm());
-        }
+        this.securePassword = parsePasswordConfiguration(passwordsConfig);
+        this.currentVersion = passwordsConfig.getVersion();
+        this.minimumVersion = passwordsConfig.getMinimumVersion();
 
         if (passwordsConfig.getValidFor() != null) {
             expirePasswords = true;
@@ -36,6 +34,11 @@ public class SecurePasswordProvider {
         } else {
             expirePasswords = false;
             passwordTtl = null;
+        }
+
+        if (passwordsConfig.getPreviousVersions() != null) {
+            this.previousVersions = passwordsConfig.getPreviousVersions().stream()
+                    .collect(Collectors.toMap(PasswordsConfig::getVersion, this::parsePasswordConfiguration));
         }
     }
 
@@ -49,5 +52,30 @@ public class SecurePasswordProvider {
 
     public Duration getPasswordTtl() {
         return passwordTtl;
+    }
+
+    public Integer getCurrentVersion() {
+        return currentVersion;
+    }
+
+    public Integer getMinimumVersion() {
+        return minimumVersion;
+    }
+
+    public Map<Integer, SecurePassword> getPreviousVersions() {
+        return previousVersions;
+    }
+
+    private SecurePassword parsePasswordConfiguration(final PasswordsConfig passwordsConfig) {
+        switch (passwordsConfig.getAlgorithm()) {
+            case "scrypt":
+                return new SCryptPassword(passwordsConfig.getScrypt());
+
+            case "bcrypt":
+                return new BCryptPassword(passwordsConfig.getBcrypt());
+
+            default:
+                throw new IllegalStateException("Unsupported password algorithm " + passwordsConfig.getAlgorithm());
+        }
     }
 }

--- a/basic-auth/src/test/java/com/nexblocks/authguard/basic/BasicAuthProviderTest.java
+++ b/basic-auth/src/test/java/com/nexblocks/authguard/basic/BasicAuthProviderTest.java
@@ -1,6 +1,7 @@
 package com.nexblocks.authguard.basic;
 
 
+import com.google.common.collect.ImmutableMap;
 import com.nexblocks.authguard.basic.passwords.SecurePassword;
 import com.nexblocks.authguard.basic.passwords.SecurePasswordProvider;
 import com.nexblocks.authguard.service.AccountsService;
@@ -10,7 +11,6 @@ import com.nexblocks.authguard.service.exceptions.ServiceException;
 import com.nexblocks.authguard.service.model.*;
 import io.vavr.control.Either;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,20 +30,24 @@ class BasicAuthProviderTest {
     private CredentialsService credentialsService;
     private SecurePasswordProvider securePasswordProvider;
     private SecurePassword securePassword;
+    private SecurePassword previousSecurePassword;
 
     private BasicAuthProvider basicAuth;
-
-    private final static EasyRandom RANDOM = new EasyRandom();
 
     @BeforeEach
     void setup() {
         accountsService = Mockito.mock(AccountsService.class);
         credentialsService = Mockito.mock(CredentialsService.class);
         securePassword = Mockito.mock(SecurePassword.class);
+        previousSecurePassword = Mockito.mock(SecurePassword.class);
 
         securePasswordProvider = Mockito.mock(SecurePasswordProvider.class);
 
         Mockito.when(securePasswordProvider.get()).thenReturn(securePassword);
+        Mockito.when(securePasswordProvider.getPreviousVersions())
+                .thenReturn(ImmutableMap.of(0, previousSecurePassword));
+        Mockito.when(securePasswordProvider.getCurrentVersion())
+                .thenReturn(1);
 
         basicAuth = new BasicAuthProvider(credentialsService, accountsService, securePasswordProvider);
     }
@@ -52,6 +56,22 @@ class BasicAuthProviderTest {
     void resetMocks() {
         Mockito.reset(accountsService);
         Mockito.reset(credentialsService);
+    }
+
+    private CredentialsBO createCredentials(final String username) {
+        return CredentialsBO.builder()
+                .id("credentials")
+                .addIdentifiers(UserIdentifierBO.builder()
+                        .identifier(username)
+                        .type(UserIdentifier.Type.USERNAME)
+                        .active(true)
+                        .build())
+                .hashedPassword(HashedPasswordBO.builder()
+                        .password("hashed")
+                        .salt("super-salt")
+                        .build())
+                .passwordVersion(1)
+                .build();
     }
 
     @Test
@@ -63,20 +83,11 @@ class BasicAuthProviderTest {
         final AccountBO account = AccountBO.builder()
                 .active(true)
                 .build();
-        final CredentialsBO credentials = RANDOM.nextObject(CredentialsBO.class)
-                .withIdentifiers(UserIdentifierBO.builder()
-                        .identifier(username)
-                        .type(UserIdentifier.Type.USERNAME)
-                        .active(true)
-                        .build());
-        final HashedPasswordBO hashedPasswordBO = HashedPasswordBO.builder()
-                .password(credentials.getHashedPassword().getPassword())
-                .salt(credentials.getHashedPassword().getSalt())
-                .build();
+        final CredentialsBO credentials = createCredentials(username);
 
         Mockito.when(credentialsService.getByUsernameUnsafe(username)).thenReturn(Optional.of(credentials));
         Mockito.when(accountsService.getById(credentials.getAccountId())).thenReturn(Optional.of(account));
-        Mockito.when(securePassword.verify(eq(password), eq(hashedPasswordBO))).thenReturn(true);
+        Mockito.when(securePassword.verify(eq(password), eq(credentials.getHashedPassword()))).thenReturn(true);
 
         final Either<Exception, AccountBO> result = basicAuth.authenticateAndGetAccount(authorization);
 
@@ -92,20 +103,11 @@ class BasicAuthProviderTest {
         final AccountBO account = AccountBO.builder()
                 .active(false)
                 .build();
-        final CredentialsBO credentials = RANDOM.nextObject(CredentialsBO.class)
-                .withIdentifiers(UserIdentifierBO.builder()
-                        .identifier(username)
-                        .type(UserIdentifier.Type.USERNAME)
-                        .active(true)
-                        .build());
-        final HashedPasswordBO hashedPasswordBO = HashedPasswordBO.builder()
-                .password(credentials.getHashedPassword().getPassword())
-                .salt(credentials.getHashedPassword().getSalt())
-                .build();
+        final CredentialsBO credentials = createCredentials(username);
 
         Mockito.when(credentialsService.getByUsernameUnsafe(username)).thenReturn(Optional.of(credentials));
         Mockito.when(accountsService.getById(credentials.getAccountId())).thenReturn(Optional.of(account));
-        Mockito.when(securePassword.verify(eq(password), eq(hashedPasswordBO))).thenReturn(true);
+        Mockito.when(securePassword.verify(eq(password), eq(credentials.getHashedPassword()))).thenReturn(true);
 
         final Either<Exception, AccountBO> result = basicAuth.authenticateAndGetAccount(authorization);
 
@@ -118,7 +120,7 @@ class BasicAuthProviderTest {
         final String password = "password";
         final String authorization = Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
 
-        final CredentialsBO credentials = RANDOM.nextObject(CredentialsBO.class)
+        final CredentialsBO credentials = createCredentials(username)
                 .withIdentifiers(UserIdentifierBO.builder()
                         .identifier(username)
                         .type(UserIdentifier.Type.USERNAME)
@@ -150,18 +152,10 @@ class BasicAuthProviderTest {
         final String password = "password";
         final String authorization = Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
 
-        final CredentialsBO credentials = RANDOM.nextObject(CredentialsBO.class)
-                .withIdentifiers(UserIdentifierBO.builder()
-                        .identifier(username)
-                        .type(UserIdentifier.Type.USERNAME)
-                        .build());
-        final HashedPasswordBO hashedPasswordBO = HashedPasswordBO.builder()
-                .password(credentials.getHashedPassword().getPassword())
-                .salt(credentials.getHashedPassword().getSalt())
-                .build();
+        final CredentialsBO credentials = createCredentials(username);
 
         Mockito.when(credentialsService.getByUsernameUnsafe(username)).thenReturn(Optional.of(credentials));
-        Mockito.when(securePassword.verify(eq(password), eq(hashedPasswordBO))).thenReturn(false);
+        Mockito.when(securePassword.verify(eq(password), eq(credentials.getHashedPassword()))).thenReturn(false);
 
         final Either<Exception, AccountBO> result = basicAuth.authenticateAndGetAccount(authorization);
 
@@ -175,21 +169,57 @@ class BasicAuthProviderTest {
         final String password = "password";
         final String authorization = Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
 
-        final CredentialsBO credentials = RANDOM.nextObject(CredentialsBO.class)
-                .withPasswordUpdatedAt(OffsetDateTime.now().minusMinutes(5))
-                .withIdentifiers(UserIdentifierBO.builder()
-                        .identifier(username)
-                        .type(UserIdentifier.Type.USERNAME)
-                        .build());
-        final HashedPasswordBO hashedPasswordBO = HashedPasswordBO.builder()
-                .password(credentials.getHashedPassword().getPassword())
-                .salt(credentials.getHashedPassword().getSalt())
-                .build();
+        final CredentialsBO credentials = createCredentials(username)
+                .withPasswordUpdatedAt(OffsetDateTime.now().minusMinutes(5));
 
         Mockito.when(credentialsService.getByUsernameUnsafe(username)).thenReturn(Optional.of(credentials));
-        Mockito.when(securePassword.verify(eq(password), eq(hashedPasswordBO))).thenReturn(true);
+        Mockito.when(securePassword.verify(eq(password), eq(credentials.getHashedPassword()))).thenReturn(true);
         Mockito.when(securePasswordProvider.passwordsExpire()).thenReturn(true);
         Mockito.when(securePasswordProvider.getPasswordTtl()).thenReturn(Duration.ofMinutes(2));
+
+        final Either<Exception, AccountBO> result = basicAuth.authenticateAndGetAccount(authorization);
+
+        assertThat(result.isLeft()).isTrue();
+        assertThat(result.getLeft()).isInstanceOf(ServiceAuthorizationException.class);
+    }
+
+    @Test
+    void authenticateWithPreviousPasswordVersion() {
+        final String username = "username";
+        final String password = "password";
+        final String authorization = Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
+
+        final AccountBO account = AccountBO.builder()
+                .active(true)
+                .build();
+        final CredentialsBO credentials = createCredentials(username)
+                .withPasswordVersion(0);
+
+        Mockito.when(credentialsService.getByUsernameUnsafe(username)).thenReturn(Optional.of(credentials));
+        Mockito.when(accountsService.getById(credentials.getAccountId())).thenReturn(Optional.of(account));
+        Mockito.when(previousSecurePassword.verify(eq(password), eq(credentials.getHashedPassword()))).thenReturn(true);
+
+        final Either<Exception, AccountBO> result = basicAuth.authenticateAndGetAccount(authorization);
+
+        assertThat(result.get()).isEqualTo(account);
+    }
+
+    @Test
+    void authenticateWithPreviousPasswordVersionWrongPassword() {
+        final String username = "username";
+        final String password = "password";
+        final String authorization = Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
+
+        final AccountBO account = AccountBO.builder()
+                .active(true)
+                .build();
+        final CredentialsBO credentials = createCredentials(username)
+                .withPasswordVersion(0);
+
+        Mockito.when(credentialsService.getByUsernameUnsafe(username)).thenReturn(Optional.of(credentials));
+        Mockito.when(accountsService.getById(credentials.getAccountId())).thenReturn(Optional.of(account));
+        Mockito.when(securePassword.verify(eq(password), eq(credentials.getHashedPassword()))).thenReturn(true);
+        Mockito.when(previousSecurePassword.verify(eq(password), eq(credentials.getHashedPassword()))).thenReturn(false);
 
         final Either<Exception, AccountBO> result = basicAuth.authenticateAndGetAccount(authorization);
 

--- a/basic-auth/src/test/java/com/nexblocks/authguard/basic/passwords/SecurePasswordProviderTest.java
+++ b/basic-auth/src/test/java/com/nexblocks/authguard/basic/passwords/SecurePasswordProviderTest.java
@@ -1,0 +1,60 @@
+package com.nexblocks.authguard.basic.passwords;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.nexblocks.authguard.config.ConfigContext;
+import com.nexblocks.authguard.config.JacksonConfigContext;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecurePasswordProviderTest {
+
+    @Test
+    void parsesWithoutPreviousVersions() {
+        final ObjectNode configRoot = new ObjectNode(JsonNodeFactory.instance)
+                .put("algorithm", "bcrypt")
+                .put("validFor", "5d");
+
+        final ObjectNode bcryptConfig = new ObjectNode(JsonNodeFactory.instance);
+        configRoot.set("bcrypt", bcryptConfig);
+
+        final ConfigContext configContext = new JacksonConfigContext(configRoot);
+
+        final SecurePasswordProvider provider = new SecurePasswordProvider(configContext);
+
+        assertThat(provider.getCurrentVersion()).isEqualTo(1);
+    }
+
+    @Test
+    void parsesWithPreviousVersions() {
+        final ObjectNode configRoot = new ObjectNode(JsonNodeFactory.instance)
+                .put("algorithm", "bcrypt")
+                .put("validFor", "5d")
+                .put("version", 2);
+
+        final ObjectNode bcryptConfig = new ObjectNode(JsonNodeFactory.instance);
+        configRoot.set("bcrypt", bcryptConfig);
+
+        final ObjectNode previousPasswordConfig = new ObjectNode(JsonNodeFactory.instance)
+                .put("algorithm", "scrypt")
+                .put("validFor", "5d")
+                .put("version",1);
+
+        final ObjectNode scryptConfig = new ObjectNode(JsonNodeFactory.instance);
+        previousPasswordConfig.set("scrypt", scryptConfig);
+
+        final ArrayNode previousVersions = new ArrayNode(JsonNodeFactory.instance)
+                .add(previousPasswordConfig);
+
+        configRoot.set("previousVersions", previousVersions);
+
+        final ConfigContext configContext = new JacksonConfigContext(configRoot);
+
+        final SecurePasswordProvider provider = new SecurePasswordProvider(configContext);
+
+        assertThat(provider.getCurrentVersion()).isEqualTo(2);
+        assertThat(provider.getPreviousVersions().get(1)).isInstanceOf(SCryptPassword.class);
+    }
+}

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/CredentialsDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/CredentialsDO.java
@@ -42,4 +42,5 @@ public class CredentialsDO extends AbstractDO {
     private PasswordDO hashedPassword;
 
     private OffsetDateTime passwordUpdatedAt;
+    private int passwordVersion;
 }

--- a/rest/src/test/java/com/nexblocks/authguard/rest/CredentialsRouteTest.java
+++ b/rest/src/test/java/com/nexblocks/authguard/rest/CredentialsRouteTest.java
@@ -5,6 +5,7 @@ import com.nexblocks.authguard.api.dto.requests.CreateCredentialsRequestDTO;
 import com.nexblocks.authguard.service.CredentialsService;
 import com.nexblocks.authguard.service.model.CredentialsBO;
 import io.restassured.http.ContentType;
+import io.restassured.response.ResponseBody;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,10 +41,12 @@ class CredentialsRouteTest extends AbstractRouteTest {
     @Test
     void create() {
         final CreateCredentialsRequestDTO credentialsRequest = randomObject(CreateCredentialsRequestDTO.class);
-        final CredentialsBO credentialsBO = mapper().toBO(credentialsRequest);
+        final CredentialsBO credentialsBO = mapper().toBO(credentialsRequest)
+                .withPasswordVersion(null);
         final CredentialsBO serviceResponse = credentialsBO
                 .withPlainPassword(null)
-                .withId(UUID.randomUUID().toString());
+                .withId(UUID.randomUUID().toString())
+                .withPasswordVersion(1);
 
         Mockito.when(credentialsService.create(Mockito.eq(credentialsBO), Mockito.any())).thenReturn(serviceResponse);
 
@@ -62,8 +65,9 @@ class CredentialsRouteTest extends AbstractRouteTest {
                 .as(CredentialsDTO.class);
 
         assertThat(responseBody).isEqualToIgnoringGivenFields(credentialsRequest,
-                "id", "plainPassword", "createdAt", "lastModified", "passwordUpdatedAt");
+                "id", "plainPassword", "createdAt", "lastModified", "passwordUpdatedAt", "passwordVersion");
         assertThat(responseBody.getPlainPassword()).isNull();
         assertThat(responseBody.getId()).isEqualTo(serviceResponse.getId());
+        assertThat(responseBody.getPasswordVersion()).isEqualTo(1);
     }
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/Credentials.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/Credentials.java
@@ -13,6 +13,7 @@ public interface Credentials extends Entity {
     String getPlainPassword();
     HashedPasswordBO getHashedPassword();
     OffsetDateTime getPasswordUpdatedAt();
+    Integer getPasswordVersion();
 
     @Override
     @Value.Derived

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/CredentialsServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/CredentialsServiceImpl.java
@@ -13,7 +13,6 @@ import com.nexblocks.authguard.emb.Messages;
 import com.nexblocks.authguard.service.AccountsService;
 import com.nexblocks.authguard.service.CredentialsService;
 import com.nexblocks.authguard.service.IdempotencyService;
-import com.nexblocks.authguard.service.exceptions.ServiceAuthorizationException;
 import com.nexblocks.authguard.service.exceptions.ServiceConflictException;
 import com.nexblocks.authguard.service.exceptions.ServiceException;
 import com.nexblocks.authguard.service.exceptions.ServiceNotFoundException;
@@ -46,6 +45,7 @@ public class CredentialsServiceImpl implements CredentialsService {
     private final PasswordValidator passwordValidator;
     private final MessageBus messageBus;
     private final ServiceMapper serviceMapper;
+    private final Integer passwordVersion;
 
     private final CryptographicRandom cryptographicRandom;
     private final PersistenceService<CredentialsBO, CredentialsDO, CredentialsRepository> persistenceService;
@@ -66,6 +66,7 @@ public class CredentialsServiceImpl implements CredentialsService {
         this.credentialsAuditRepository = credentialsAuditRepository;
         this.accountTokensRepository = accountTokensRepository;
         this.securePassword = securePasswordProvider.get();
+        this.passwordVersion = securePasswordProvider.getCurrentVersion();
         this.passwordValidator = passwordValidator;
         this.messageBus = messageBus;
         this.serviceMapper = serviceMapper;
@@ -91,6 +92,7 @@ public class CredentialsServiceImpl implements CredentialsService {
                 .hashedPassword(hashedPassword)
                 .id(ID.generate())
                 .passwordUpdatedAt(OffsetDateTime.now())
+                .passwordVersion(passwordVersion)
                 .build();
 
         return removeSensitiveInformation(persistenceService.create(credentialsHashedPassword));


### PR DESCRIPTION
Added support for password versions:
1. Minimum version can be set, and any password with an older version
   will be deemed expired.
2. Previous versions configurations can be kept to be able to hash
   using older versions for older passwords