### PR TITLE
Migrate from string IDs to number IDs

### DIFF
--- a/api/src/main/java/com/nexblocks/authguard/api/dto/entities/Account.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/entities/Account.java
@@ -15,7 +15,7 @@ import java.util.Map;
 @JsonSerialize(as = AccountDTO.class)
 @JsonDeserialize(as = AccountDTO.class)
 public interface Account {
-    String getId();
+    long getId();
     Instant getCreatedAt();
     Instant getLastModified();
 

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/entities/AccountLock.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/entities/AccountLock.java
@@ -8,6 +8,6 @@ import java.time.Instant;
 @Value.Immutable
 @DTOStyle
 public interface AccountLock {
-    String getAccountId();
+    long getAccountId();
     Instant getExpiresAt();
 }

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/entities/ActionToken.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/entities/ActionToken.java
@@ -12,6 +12,6 @@ import org.immutables.value.Value;
 public interface ActionToken {
     String getToken();
     String getAction();
-    String getAccountId();
+    Long getAccountId();
     long getValidFor();
 }

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/entities/ApiKey.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/entities/ApiKey.java
@@ -12,10 +12,10 @@ import java.time.Instant;
 @JsonSerialize(as = ApiKeyDTO.class)
 @JsonDeserialize(as = ApiKeyDTO.class)
 public interface ApiKey {
-    String getId();
+    long getId();
     Instant getCreatedAt();
     Instant getLastModified();
-    String getAppId();
+    Long getAppId();
     String getKey();
     String getType();
     boolean isForClient();

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/entities/App.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/entities/App.java
@@ -13,12 +13,12 @@ import java.util.List;
 @JsonSerialize(as = AppDTO.class)
 @JsonDeserialize(as = AppDTO.class)
 public interface App {
-    String getId();
+    long getId();
     Instant getCreatedAt();
     Instant getLastModified();
     String getExternalId();
     String getName();
-    String getAccountId();
+    Long getAccountId();
     String getDomain();
     String getBaseUrl();
     List<PermissionDTO> getPermissions();

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/entities/Client.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/entities/Client.java
@@ -12,12 +12,12 @@ import java.time.Instant;
 @JsonSerialize(as = ClientDTO.class)
 @JsonDeserialize(as = ClientDTO.class)
 public interface Client {
-    String getId();
+    long getId();
     Instant getCreatedAt();
     Instant getLastModified();
     String getExternalId();
     String getName();
-    String getAccountId();
+    Long getAccountId();
     String getDomain();
     String getBaseUrl();
     String getClientType();

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/entities/Credentials.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/entities/Credentials.java
@@ -11,7 +11,7 @@ import java.util.List;
 @DTOStyle
 @JsonDeserialize(as = CredentialsDTO.class)
 public interface Credentials {
-    String getId();
+    long getId();
     Instant getCreatedAt();
     Instant getLastModified();
     Instant getPasswordUpdatedAt();

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/entities/ExchangeAttempt.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/entities/ExchangeAttempt.java
@@ -8,10 +8,10 @@ import java.time.Instant;
 @Value.Immutable
 @DTOStyle
 public interface ExchangeAttempt {
-    String getId();
+    long getId();
     Instant getCreatedAt();
     Instant getLastModified();
-    String getEntityId();
+    Long getEntityId();
     String getExchangeFrom();
     String getExchangeTo();
     boolean isSuccessful();

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/entities/Permission.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/entities/Permission.java
@@ -12,7 +12,7 @@ import java.time.Instant;
 @JsonSerialize(as = PermissionDTO.class)
 @JsonDeserialize(as = PermissionDTO.class)
 public interface Permission {
-    String getId();
+    long getId();
     Instant getCreatedAt();
     Instant getLastModified();
     String getGroup();

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/entities/Role.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/entities/Role.java
@@ -12,7 +12,7 @@ import java.time.Instant;
 @JsonDeserialize(as = RoleDTO.class)
 @JsonSerialize(as = RoleDTO.class)
 public interface Role {
-    String getId();
+    long getId();
     Instant getCreatedAt();
     Instant getLastModified();
     String getName();

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/requests/ApiKeyRequest.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/requests/ApiKeyRequest.java
@@ -14,7 +14,7 @@ import java.time.Instant;
 public interface ApiKeyRequest {
     boolean isForClient();
     String getKeyType();
-    String getAppId();
+    Long getAppId();
     Instant getExpiresAt();
     DurationRequestDTO getValidFor();
 }

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/requests/CreateAppRequest.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/requests/CreateAppRequest.java
@@ -15,7 +15,7 @@ import java.util.List;
 public interface CreateAppRequest {
     String getExternalId();
     String getName();
-    String getAccountId();
+    Long getAccountId();
     String getDomain();
     List<PermissionDTO> getPermissions();
     List<String> getScopes();

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/requests/CreateClientRequest.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/requests/CreateClientRequest.java
@@ -13,7 +13,7 @@ import org.immutables.value.Value;
 public interface CreateClientRequest {
     String getExternalId();
     String getName();
-    String getAccountId();
+    Long getAccountId();
     String getDomain();
     String getBaseUrl();
     ClientType getClientType();

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/requests/OtpRequest.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/requests/OtpRequest.java
@@ -10,6 +10,6 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = OtpRequestDTO.class)
 @JsonSerialize(as = OtpRequestDTO.class)
 public interface OtpRequest {
-    String getPasswordId();
+    Long getPasswordId();
     String getPassword();
 }

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/validation/validators/ApiKeysRequestValidator.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/validation/validators/ApiKeysRequestValidator.java
@@ -14,7 +14,7 @@ public class ApiKeysRequestValidator implements Validator<ApiKeyRequestDTO> {
     @Override
     public List<Violation> validate(final ApiKeyRequestDTO obj) {
         return FluentValidator.begin()
-                .validate("appId", obj.getAppId(), Constraints.required, Constraints.reasonableLength)
+                .validate("appId", obj.getAppId(), Constraints.required)
                 .validate("keyType", obj.getKeyType(), Constraints.required, Constraints.reasonableLength)
                 .validate("validFor", obj.getValidFor(), durationRequest -> {
                     if (durationRequest == null) {

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/validation/validators/CreateAppRequestValidator.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/validation/validators/CreateAppRequestValidator.java
@@ -12,7 +12,6 @@ public class CreateAppRequestValidator implements Validator<CreateAppRequest> {
     public List<Violation> validate(final CreateAppRequest obj) {
         return FluentValidator.begin()
                 .validate("externalId", obj.getExternalId(), Constraints.reasonableLength)
-                .validate("accountId", obj.getAccountId(), Constraints.reasonableLength)
                 .validate("name", obj.getName(), Constraints.required, Constraints.reasonableLength)
                 .validate("domain", obj.getDomain(), Constraints.required)
                 .getViolations();

--- a/api/src/main/java/com/nexblocks/authguard/api/dto/validation/validators/CreateClientRequestValidator.java
+++ b/api/src/main/java/com/nexblocks/authguard/api/dto/validation/validators/CreateClientRequestValidator.java
@@ -12,7 +12,6 @@ public class CreateClientRequestValidator implements Validator<CreateClientReque
     public List<Violation> validate(CreateClientRequestDTO obj) {
         return FluentValidator.begin()
                 .validate("externalId", obj.getExternalId(), Constraints.reasonableLength)
-                .validate("accountId", obj.getAccountId(), Constraints.reasonableLength)
                 .validate("name", obj.getName(), Constraints.required, Constraints.reasonableLength)
                 .validate("domain", obj.getDomain(), Constraints.required)
                 .validate("clientType", obj.getClientType(), Constraints.required)

--- a/api/src/test/java/com/nexblocks/authguard/api/dto/validation/validators/ApiKeysRequestValidatorTest.java
+++ b/api/src/test/java/com/nexblocks/authguard/api/dto/validation/validators/ApiKeysRequestValidatorTest.java
@@ -17,7 +17,7 @@ class ApiKeysRequestValidatorTest {
     @Test
     void validate() {
         final ApiKeyRequestDTO request = ApiKeyRequestDTO.builder()
-                .appId("app")
+                .appId(1L)
                 .keyType("default")
                 .build();
 
@@ -44,7 +44,7 @@ class ApiKeysRequestValidatorTest {
     @Test
     void validateWithZeroValidity() {
         final ApiKeyRequestDTO request = ApiKeyRequestDTO.builder()
-                .appId("app")
+                .appId(1L)
                 .keyType("default")
                 .validFor(DurationRequestDTO.builder()
                         .build())
@@ -59,7 +59,7 @@ class ApiKeysRequestValidatorTest {
     @Test
     void validateWithNonZeroValidity() {
         final ApiKeyRequestDTO request = ApiKeyRequestDTO.builder()
-                .appId("app")
+                .appId(1L)
                 .keyType("default")
                 .validFor(DurationRequestDTO.builder()
                         .days(1)
@@ -77,7 +77,7 @@ class ApiKeysRequestValidatorTest {
     @Test
     void validateWithNegativeDaysValidity() {
         final ApiKeyRequestDTO request = ApiKeyRequestDTO.builder()
-                .appId("app")
+                .appId(1L)
                 .keyType("default")
                 .validFor(DurationRequestDTO.builder()
                         .days(-1)
@@ -95,7 +95,7 @@ class ApiKeysRequestValidatorTest {
     @Test
     void validateWithNegativeHoursValidity() {
         final ApiKeyRequestDTO request = ApiKeyRequestDTO.builder()
-                .appId("app")
+                .appId(1L)
                 .keyType("default")
                 .validFor(DurationRequestDTO.builder()
                         .hours(-1)
@@ -113,7 +113,7 @@ class ApiKeysRequestValidatorTest {
     @Test
     void validateWithNegativeMinutesValidity() {
         final ApiKeyRequestDTO request = ApiKeyRequestDTO.builder()
-                .appId("app")
+                .appId(1L)
                 .keyType("default")
                 .validFor(DurationRequestDTO.builder()
                         .minutes(-1)

--- a/api/src/test/java/com/nexblocks/authguard/api/dto/validation/validators/OtpRequestValidatorTest.java
+++ b/api/src/test/java/com/nexblocks/authguard/api/dto/validation/validators/OtpRequestValidatorTest.java
@@ -15,7 +15,7 @@ class OtpRequestValidatorTest {
     @Test
     void validateValid() {
         final OtpRequestDTO request = OtpRequestDTO.builder()
-                .passwordId("password-id")
+                .passwordId(1L)
                 .password("password")
                 .build();
 

--- a/basic-auth/src/main/java/com/nexblocks/authguard/basic/otp/OtpProvider.java
+++ b/basic-auth/src/main/java/com/nexblocks/authguard/basic/otp/OtpProvider.java
@@ -92,7 +92,7 @@ public class OtpProvider implements AuthProvider {
         throw new UnsupportedOperationException("OTPs cannot be generated for applications");
     }
 
-    private AuthResponseBO createToken(final String passwordId, final String accountId) {
+    private AuthResponseBO createToken(final long passwordId, final long accountId) {
         return AuthResponseBO.builder()
                 .type(TOKEN_TYPE)
                 .token(passwordId)

--- a/basic-auth/src/main/java/com/nexblocks/authguard/basic/otp/OtpVerifier.java
+++ b/basic-auth/src/main/java/com/nexblocks/authguard/basic/otp/OtpVerifier.java
@@ -11,7 +11,6 @@ import com.google.inject.Inject;
 import io.vavr.control.Either;
 
 import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.util.Optional;
 
 public class OtpVerifier implements AuthVerifier {
@@ -25,7 +24,7 @@ public class OtpVerifier implements AuthVerifier {
     }
 
     @Override
-    public Either<Exception, String> verifyAccountToken(final String token) {
+    public Either<Exception, Long> verifyAccountToken(final String token) {
         // TODO: no need to have a special format for the token, just receive the two parts in the request
         final String[] parts = token.split(":");
 
@@ -34,7 +33,14 @@ public class OtpVerifier implements AuthVerifier {
                     "Invalid OTP token format"));
         }
 
-        final String passwordId = parts[0];
+        final long passwordId;
+
+        try {
+            passwordId = Long.parseLong(parts[0]);
+        } catch (Exception e) {
+            return Either.left(new ServiceAuthorizationException(ErrorCode.INVALID_AUTHORIZATION_FORMAT,
+                    "Invalid OTP ID"));
+        }
         final String otp = parts[1];
 
         final Optional<OneTimePasswordBO> generatedOpt = otpRepository.getById(passwordId)

--- a/basic-auth/src/main/java/com/nexblocks/authguard/basic/passwordless/PasswordlessVerifier.java
+++ b/basic-auth/src/main/java/com/nexblocks/authguard/basic/passwordless/PasswordlessVerifier.java
@@ -10,7 +10,6 @@ import com.google.inject.Inject;
 import io.vavr.control.Either;
 
 import java.time.Instant;
-import java.time.OffsetDateTime;
 
 public class PasswordlessVerifier implements AuthVerifier {
     private final AccountTokensRepository accountTokensRepository;
@@ -21,7 +20,7 @@ public class PasswordlessVerifier implements AuthVerifier {
     }
 
     @Override
-    public Either<Exception, String> verifyAccountToken(final String passwordlessToken) {
+    public Either<Exception, Long> verifyAccountToken(final String passwordlessToken) {
         return accountTokensRepository.getByToken(passwordlessToken)
                 .join()
                 .map(this::verifyToken)
@@ -29,7 +28,7 @@ public class PasswordlessVerifier implements AuthVerifier {
                         "No passwordless token found for " + passwordlessToken)));
     }
 
-    private Either<Exception, String> verifyToken(final AccountTokenDO accountToken) {
+    private Either<Exception, Long> verifyToken(final AccountTokenDO accountToken) {
         if (accountToken.getExpiresAt().isBefore(Instant.now())) {
             return Either.left(new ServiceAuthorizationException(ErrorCode.EXPIRED_TOKEN, "Expired passwordless token",
                     EntityType.ACCOUNT, accountToken.getAssociatedAccountId()));

--- a/basic-auth/src/test/java/com/nexblocks/authguard/basic/BasicAuthProviderTest.java
+++ b/basic-auth/src/test/java/com/nexblocks/authguard/basic/BasicAuthProviderTest.java
@@ -53,7 +53,7 @@ class BasicAuthProviderTest {
 
     private AccountBO createCredentials(final String username) {
         return AccountBO.builder()
-                .id("credentials")
+                .id(1)
                 .active(true)
                 .addIdentifiers(UserIdentifierBO.builder()
                         .identifier(username)
@@ -213,12 +213,6 @@ class BasicAuthProviderTest {
 
         assertThat(result.isLeft()).isTrue();
         assertThat(result.getLeft()).isInstanceOf(ServiceAuthorizationException.class);
-    }
-
-    @Test
-    void authenticateBadAuthorization() {
-        final String authorization = RandomStringUtils.randomAlphanumeric(20);
-        assertThatThrownBy(() -> basicAuth.authenticateAndGetAccount(authorization)).isInstanceOf(ServiceException.class);
     }
 
     @Test

--- a/basic-auth/src/test/java/com/nexblocks/authguard/basic/otp/OtpVerifierTest.java
+++ b/basic-auth/src/test/java/com/nexblocks/authguard/basic/otp/OtpVerifierTest.java
@@ -51,7 +51,7 @@ class OtpVerifierTest {
         Mockito.when(mockOtpRepository.getById(otp.getId()))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(otp)));
 
-        final Either<Exception, String> generated = otpVerifier.verifyAccountToken(otp.getId() + ":" + otp.getPassword());
+        final Either<Exception, Long> generated = otpVerifier.verifyAccountToken(otp.getId() + ":" + otp.getPassword());
 
         assertThat(generated.get()).isEqualTo(otp.getAccountId());
     }
@@ -84,7 +84,7 @@ class OtpVerifierTest {
 
         setup(otpConfig);
 
-        final Either<Exception, String> result = otpVerifier.verifyAccountToken("not a valid OTP");
+        final Either<Exception, Long> result = otpVerifier.verifyAccountToken("not a valid OTP");
 
         assertThat(result.isLeft()).isTrue();
         assertThat(result.getLeft()).isInstanceOf(ServiceAuthorizationException.class);
@@ -105,7 +105,7 @@ class OtpVerifierTest {
         Mockito.when(mockOtpRepository.getById(otp.getId()))
                 .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
-        final Either<Exception, String> result = otpVerifier.verifyAccountToken(otp.getId() + ":" + otp.getPassword());
+        final Either<Exception, Long> result = otpVerifier.verifyAccountToken(otp.getId() + ":" + otp.getPassword());
 
         assertThat(result.isLeft()).isTrue();
         assertThat(result.getLeft()).isInstanceOf(ServiceAuthorizationException.class);

--- a/basic-auth/src/test/java/com/nexblocks/authguard/basic/passwordless/PasswordlessProviderTest.java
+++ b/basic-auth/src/test/java/com/nexblocks/authguard/basic/passwordless/PasswordlessProviderTest.java
@@ -52,7 +52,7 @@ class PasswordlessProviderTest {
         setup(passwordlessConfig);
 
         final AccountBO account = AccountBO.builder()
-                .id("account")
+                .id(101)
                 .active(true)
                 .build();
 

--- a/dal/cache/src/main/java/com/nexblocks/authguard/dal/cache/AccountLocksRepository.java
+++ b/dal/cache/src/main/java/com/nexblocks/authguard/dal/cache/AccountLocksRepository.java
@@ -7,9 +7,9 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public interface AccountLocksRepository {
-    CompletableFuture<Collection<AccountLockDO>> findByAccountId(String accountId);
+    CompletableFuture<Collection<AccountLockDO>> findByAccountId(long accountId);
 
     CompletableFuture<AccountLockDO> save(AccountLockDO accountLock);
 
-    CompletableFuture<Optional<AccountLockDO>> delete(String id);
+    CompletableFuture<Optional<AccountLockDO>> delete(long id);
 }

--- a/dal/cache/src/main/java/com/nexblocks/authguard/dal/cache/OtpRepository.java
+++ b/dal/cache/src/main/java/com/nexblocks/authguard/dal/cache/OtpRepository.java
@@ -7,5 +7,5 @@ import java.util.concurrent.CompletableFuture;
 
 public interface OtpRepository {
     CompletableFuture<OneTimePasswordDO> save(OneTimePasswordDO password);
-    CompletableFuture<Optional<OneTimePasswordDO>> getById(String id);
+    CompletableFuture<Optional<OneTimePasswordDO>> getById(long id);
 }

--- a/dal/cache/src/main/java/com/nexblocks/authguard/dal/cache/SessionsRepository.java
+++ b/dal/cache/src/main/java/com/nexblocks/authguard/dal/cache/SessionsRepository.java
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletableFuture;
 public interface SessionsRepository {
     CompletableFuture<SessionDO> save(final SessionDO session);
 
-    CompletableFuture<Optional<SessionDO>> getById(final String sessionId);
+    CompletableFuture<Optional<SessionDO>> getById(final long sessionId);
 
     CompletableFuture<Optional<SessionDO>> getByToken(final String sessionToken);
 

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/AbstractDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/AbstractDO.java
@@ -19,8 +19,7 @@ import java.time.Instant;
 @MappedSuperclass
 public abstract class AbstractDO {
     @Id
-    @Convert(converter = LongToStringConverter.class)
-    private String id;
+    private long id;
     private boolean deleted;
     private Instant createdAt;
     private Instant lastModified;

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/AccountLockDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/AccountLockDO.java
@@ -23,6 +23,6 @@ import java.time.Instant;
                 "WHERE lock.accountId = :accountId AND lock.deleted = false"
 )
 public class AccountLockDO extends AbstractDO {
-    private String accountId;
+    private long accountId;
     private Instant expiresAt;
 }

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/AccountTokenDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/AccountTokenDO.java
@@ -25,7 +25,7 @@ import java.util.Map;
 )
 public class AccountTokenDO extends AbstractDO {
     private String token;
-    private String associatedAccountId;
+    private long associatedAccountId;
     private Instant expiresAt;
     private String sourceAuthType;
     private String deviceId;

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/ApiKeyDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/ApiKeyDO.java
@@ -39,7 +39,7 @@ import java.time.Instant;
 )
 public class ApiKeyDO extends AbstractDO {
     private String key;
-    private String appId;
+    private long appId;
     private String type;
     private boolean forClient;
     private Instant expiresAt;

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/AppDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/AppDO.java
@@ -30,7 +30,7 @@ import java.util.Set;
 public class AppDO extends AbstractDO {
     private String externalId;
     private String name;
-    private String parentAccountId;
+    private Long parentAccountId;
     private String domain;
     private String baseUrl;
 

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/ClientDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/ClientDO.java
@@ -39,7 +39,7 @@ import javax.persistence.Table;
 public class ClientDO extends AbstractDO {
     private String externalId;
     private String name;
-    private String accountId;
+    private Long accountId;
     private String domain;
     private String baseUrl;
     private String clientType;

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/CredentialsAuditDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/CredentialsAuditDO.java
@@ -23,7 +23,7 @@ import javax.persistence.Table;
 )
 public class CredentialsAuditDO extends AbstractDO {
     private Action action;
-    private String credentialsId;
+    private long credentialsId;
 
     private String identifier;
 

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/CredentialsDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/CredentialsDO.java
@@ -33,7 +33,7 @@ import java.util.Set;
                 "WHERE identifier.identifier = :identifier AND identifier.domain = :domain AND credentials.deleted = false"
 )
 public class CredentialsDO extends AbstractDO {
-    private String accountId;
+    private long accountId;
 
     @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     private Set<UserIdentifierDO> identifiers;

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/ExchangeAttemptDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/ExchangeAttemptDO.java
@@ -33,7 +33,7 @@ import javax.persistence.Table;
                 "AND attempt.createdAt > :timestamp"
 )
 public class ExchangeAttemptDO extends AbstractDO {
-    private String entityId;
+    private long entityId;
     private String exchangeFrom;
     private String exchangeTo;
     private boolean successful;

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/IdempotentRecordDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/IdempotentRecordDO.java
@@ -26,6 +26,6 @@ import javax.persistence.Table;
 )
 public class IdempotentRecordDO extends AbstractDO {
     private String idempotentKey;
-    private String entityId;
+    private long entityId;
     private String entityType;
 }

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/OneTimePasswordDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/OneTimePasswordDO.java
@@ -17,7 +17,7 @@ import java.time.Instant;
 @Entity
 @Table(name = "otps")
 public class OneTimePasswordDO extends AbstractDO {
-    private String accountId;
+    private long accountId;
     private String password;
     private Instant expiresAt;
     private String deviceId;

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/SessionDO.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/model/SessionDO.java
@@ -24,7 +24,7 @@ import java.util.Map;
 )
 public class SessionDO extends AbstractDO {
     private String sessionToken;
-    private String accountId;
+    private long accountId;
     private Instant expiresAt;
 
     @ElementCollection(fetch = FetchType.EAGER)

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/repository/IndelibleRecordRepository.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/repository/IndelibleRecordRepository.java
@@ -5,7 +5,7 @@ import java.util.concurrent.CompletableFuture;
 
 public interface IndelibleRecordRepository<T> extends Repository<T> {
     @Override
-    default CompletableFuture<Optional<T>> delete(final String id) {
+    default CompletableFuture<Optional<T>> delete(final long id) {
         return CompletableFuture.failedFuture(new UnsupportedOperationException());
     }
 }

--- a/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/repository/Repository.java
+++ b/dal/dal-common/src/main/java/com/nexblocks/authguard/dal/repository/Repository.java
@@ -4,8 +4,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public interface Repository<T> {
-    CompletableFuture<Optional<T>> getById(String id);
+    CompletableFuture<Optional<T>> getById(long id);
     CompletableFuture<T> save(T entity);
     CompletableFuture<Optional<T>> update(T entity);
-    CompletableFuture<Optional<T>> delete(String id);
+    CompletableFuture<Optional<T>> delete(long id);
 }

--- a/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/AccountJpaTest.java
+++ b/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/AccountJpaTest.java
@@ -21,6 +21,9 @@ class AccountJpaTest {
     private AccountDO createdAccount;
     private AccountDO deletedAccount;
 
+    private int idCounter = 1;
+    private int readPermissionId;
+
     @BeforeAll
     void setup() {
         final H2 h2 = new H2().withMappedClass(AccountDO.class)
@@ -35,11 +38,13 @@ class AccountJpaTest {
         // create test permission
         entityManager.getTransaction().begin();
 
-        entityManager.persist(PermissionDO.builder()
-                .id("read-posts-permission")
+        readPermissionId = idCounter++;
+        PermissionDO readPostsPermission = PermissionDO.builder()
+                .id(readPermissionId)
                 .group("posts")
                 .name("read")
-                .build());
+                .build();
+        entityManager.persist(readPostsPermission);
 
         entityManager.getTransaction().commit();
 
@@ -47,11 +52,11 @@ class AccountJpaTest {
         entityManager.getTransaction().begin();
 
         createdAccount = AccountDO.builder()
-                .id("1")
+                .id(idCounter++)
                 .roles(Collections.singleton("test"))
                 .externalId("test-account-external")
                 .permissions(Collections.singleton(PermissionDO.builder()
-                        .id("read-posts-permission")
+                        .id(readPostsPermission.getId())
                         .group("posts")
                         .name("read")
                         .build()))
@@ -75,12 +80,12 @@ class AccountJpaTest {
                 .build();
 
         deletedAccount = AccountDO.builder()
-                .id("deleted-account")
+                .id(idCounter++)
                 .deleted(true)
                 .roles(Collections.singleton("test"))
                 .externalId("test-account-external")
                 .permissions(Collections.singleton(PermissionDO.builder()
-                        .id("read-posts-permission")
+                        .id(readPostsPermission.getId())
                         .build()))
                 .email(EmailDO.builder()
                         .email("deleted@emails.com")
@@ -157,10 +162,10 @@ class AccountJpaTest {
         entityManager.getTransaction().begin();
 
         entityManager.persist(AccountDO.builder()
-                .id("not-to-be-inserted")
+                .id(idCounter++)
                 .roles(Collections.singleton("test"))
                 .permissions(Collections.singleton(PermissionDO.builder()
-                        .id("read-posts-permission")
+                        .id(readPermissionId)
                         .build()))
                 .email(EmailDO.builder()
                         .email("primary@emails.com")
@@ -225,7 +230,7 @@ class AccountJpaTest {
     @Test
     void createDuplicate() {
         final AccountDO duplicate = AccountDO.builder()
-                .id("duplicate-credentials")
+                .id(idCounter++)
                 .hashedPassword(PasswordDO.builder()
                         .password("password")
                         .salt("salt")

--- a/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/AccountLockJpaTest.java
+++ b/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/AccountLockJpaTest.java
@@ -24,9 +24,9 @@ public class AccountLockJpaTest {
         entityManager = h2.getEntityManager();
 
         createdLock = AccountLockDO.builder()
-                .id("account-lock-id")
+                .id(1)
                 .expiresAt(Instant.now())
-                .accountId("account")
+                .accountId(101)
                 .build();
 
         entityManager.getTransaction().begin();

--- a/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/AccountTokenJpaTest.java
+++ b/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/AccountTokenJpaTest.java
@@ -27,10 +27,10 @@ public class AccountTokenJpaTest {
         entityManager = h2.getEntityManager();
 
         createdAccountToken = AccountTokenDO.builder()
-                .id("account-token-id")
+                .id(1)
                 .token("test-token")
                 .expiresAt(Instant.now())
-                .associatedAccountId("account")
+                .associatedAccountId(101)
                 .additionalInformation(ImmutableMap.of("key", "value"))
                 .build();
 

--- a/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/ApiKeyJpaTest.java
+++ b/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/ApiKeyJpaTest.java
@@ -24,15 +24,15 @@ public class ApiKeyJpaTest {
         entityManager = h2.getEntityManager();
 
         createdApiKey = ApiKeyDO.builder()
-                .id("api-key-id")
-                .appId("app-id")
+                .id(1)
+                .appId(101)
                 .key("key")
                 .build();
 
         deletedAPiKey = ApiKeyDO.builder()
-                .id("deleted-api-key-id")
+                .id(2)
                 .deleted(true)
-                .appId("app-id")
+                .appId(101)
                 .key("deleted-key")
                 .build();
 

--- a/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/AppJpaTest.java
+++ b/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/AppJpaTest.java
@@ -27,16 +27,16 @@ public class AppJpaTest {
 
         // create test app
         createdApp = AppDO.builder()
-                .id("test-app")
-                .parentAccountId("parent-account")
+                .id(1)
+                .parentAccountId(101L)
                 .name("Test Application")
                 .externalId("external-id")
                 .build();
 
         deletedApp = AppDO.builder()
-                .id("deleted-app")
+                .id(2)
                 .deleted(true)
-                .parentAccountId("parent-account")
+                .parentAccountId(101L)
                 .name("Test Application")
                 .externalId("external-id")
                 .build();

--- a/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/CredentialsAuditJpaTest.java
+++ b/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/CredentialsAuditJpaTest.java
@@ -26,8 +26,8 @@ public class CredentialsAuditJpaTest {
 
         // create audit
         created = CredentialsAuditDO.builder()
-                .id("credentials-audit")
-                .credentialsId("credentials")
+                .id(1)
+                .credentialsId(101)
                 .action(CredentialsAuditDO.Action.UPDATED)
                 .password(PasswordDO.builder()
                         .password("password")

--- a/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/CredentialsJpaTest.java
+++ b/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/CredentialsJpaTest.java
@@ -31,8 +31,8 @@ public class CredentialsJpaTest {
 
         // create credentials
         createdCredentials = CredentialsDO.builder()
-                .id("created-credentials")
-                .accountId("account")
+                .id(1)
+                .accountId(101)
                 .hashedPassword(PasswordDO.builder()
                         .password("password")
                         .salt("salt")
@@ -45,9 +45,9 @@ public class CredentialsJpaTest {
                 .build();
 
         deletedCredentials = CredentialsDO.builder()
-                .id("deleted-credentials")
+                .id(2)
                 .deleted(true)
-                .accountId("account")
+                .accountId(101)
                 .hashedPassword(PasswordDO.builder()
                         .password("password")
                         .salt("salt")
@@ -117,8 +117,8 @@ public class CredentialsJpaTest {
     @Test
     void createDuplicate() {
         final CredentialsDO duplicate = CredentialsDO.builder()
-                .id("duplicate-credentials")
-                .accountId("account")
+                .id(3)
+                .accountId(101)
                 .hashedPassword(PasswordDO.builder()
                         .password("password")
                         .salt("salt")

--- a/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/ExchangeAttemptJpaTest.java
+++ b/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/ExchangeAttemptJpaTest.java
@@ -29,24 +29,24 @@ public class ExchangeAttemptJpaTest {
         entityManager.getTransaction().begin();
 
         firstAttempt = ExchangeAttemptDO.builder()
-                .id("first-attempt")
-                .entityId("account")
+                .id(1)
+                .entityId(101)
                 .exchangeFrom("basic")
                 .exchangeTo("unknown")
                 .createdAt(Instant.now().minus(Duration.ofHours(3)))
                 .build();
 
         secondAttempt = ExchangeAttemptDO.builder()
-                .id("second-attempt")
-                .entityId("account")
+                .id(2)
+                .entityId(101)
                 .exchangeFrom("jwt")
                 .exchangeTo("unknown")
                 .createdAt(Instant.now().minus(Duration.ofHours(1)))
                 .build();
 
         thirdAttempt = ExchangeAttemptDO.builder()
-                .id("third-attempt")
-                .entityId("application")
+                .id(3)
+                .entityId(201)
                 .exchangeFrom("id")
                 .exchangeTo("api")
                 .createdAt(Instant.now().minus(Duration.ofHours(1)))
@@ -62,7 +62,7 @@ public class ExchangeAttemptJpaTest {
     @Test
     void getByEntityId() {
         final TypedQuery<ExchangeAttemptDO> query = entityManager.createNamedQuery("exchange_attempts.getByEntityId",
-                ExchangeAttemptDO.class).setParameter("entityId", "account");
+                ExchangeAttemptDO.class).setParameter("entityId", firstAttempt.getEntityId());
 
         final List<ExchangeAttemptDO> retrieved = query.getResultList();
         Assertions.assertThat(retrieved).containsExactly(firstAttempt, secondAttempt);
@@ -72,7 +72,7 @@ public class ExchangeAttemptJpaTest {
     void getByEntityIdFromTimestamp() {
         final TypedQuery<ExchangeAttemptDO> query = entityManager.createNamedQuery(
                 "exchange_attempts.getByEntityIdFromTimestamp", ExchangeAttemptDO.class)
-                .setParameter("entityId", "account")
+                .setParameter("entityId", firstAttempt.getEntityId())
                 .setParameter("timestamp", Instant.now().minus(Duration.ofHours(2)));
 
         final List<ExchangeAttemptDO> retrieved = query.getResultList();
@@ -83,7 +83,7 @@ public class ExchangeAttemptJpaTest {
     void getByEntityIdAndExchangeFromTimestamp() {
         final TypedQuery<ExchangeAttemptDO> query = entityManager.createNamedQuery(
                 "exchange_attempts.getByEntityIdAndExchangeFromTimestamp", ExchangeAttemptDO.class)
-                .setParameter("entityId", "account")
+                .setParameter("entityId", firstAttempt.getEntityId())
                 .setParameter("timestamp", Instant.now().minus(Duration.ofHours(4)))
                 .setParameter("exchangeFrom", "basic");
 

--- a/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/IdempotentRecordJpaTest.java
+++ b/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/IdempotentRecordJpaTest.java
@@ -26,17 +26,17 @@ public class IdempotentRecordJpaTest {
 
         // create record
         first = IdempotentRecordDO.builder()
-                .id("first-idempotent-record")
+                .id(1)
                 .idempotentKey("idempotent-key")
                 .entityType("FirstEntity")
-                .entityId("first-entity")
+                .entityId(101)
                 .build();
 
         second = IdempotentRecordDO.builder()
-                .id("second-idempotent-record")
+                .id(2)
                 .idempotentKey("idempotent-key")
                 .entityType("SecondEntity")
-                .entityId("second-entity")
+                .entityId(102)
                 .build();
 
         entityManager.getTransaction().begin();

--- a/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/PermissionsJpaTest.java
+++ b/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/PermissionsJpaTest.java
@@ -26,21 +26,21 @@ public class PermissionsJpaTest {
 
         // create entities
         first = PermissionDO.builder()
-                .id("first-permission")
+                .id(1)
                 .group("test")
                 .name("read")
                 .domain("main")
                 .build();
 
         second = PermissionDO.builder()
-                .id("second-permission")
+                .id(2)
                 .group("test")
                 .name("write")
                 .domain("main")
                 .build();
 
         deleted = PermissionDO.builder()
-                .id("deleted-permission")
+                .id(3)
                 .deleted(true)
                 .group("test")
                 .name("delete")

--- a/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/RolesJpaTest.java
+++ b/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/RolesJpaTest.java
@@ -27,19 +27,19 @@ public class RolesJpaTest {
 
         // create entities
         first = RoleDO.builder()
-                .id("first-role")
+                .id(1)
                 .name("role-1")
                 .domain("main")
                 .build();
 
         second = RoleDO.builder()
-                .id("second-role")
+                .id(2)
                 .name("role-2")
                 .domain("main")
                 .build();
 
         deleted = RoleDO.builder()
-                .id("deleted-role")
+                .id(3)
                 .deleted(true)
                 .name("role-3")
                 .domain("main")

--- a/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/SessionsJpaTest.java
+++ b/dal/dal-common/src/test/java/com/nexblocks/authguard/dal/model/SessionsJpaTest.java
@@ -28,12 +28,12 @@ public class SessionsJpaTest {
 
         // create entities
         first = SessionDO.builder()
-                .id("first-session")
+                .id(1)
                 .sessionToken("token-1")
                 .build();
 
         second = SessionDO.builder()
-                .id("second-session")
+                .id(2)
                 .sessionToken("token-2")
                 .build();
 
@@ -59,7 +59,7 @@ public class SessionsJpaTest {
         entityManager.getTransaction().begin();
 
         entityManager.persist(SessionDO.builder()
-                .id("duplicate")
+                .id(3)
                 .sessionToken(first.getSessionToken())
                 .build());
 

--- a/dal/persistence/src/main/java/com/nexblocks/authguard/dal/persistence/ApiKeysRepository.java
+++ b/dal/persistence/src/main/java/com/nexblocks/authguard/dal/persistence/ApiKeysRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public interface ApiKeysRepository extends ImmutableRecordRepository<ApiKeyDO> {
-    CompletableFuture<Collection<ApiKeyDO>> getByAppId(String id);
+    CompletableFuture<Collection<ApiKeyDO>> getByAppId(long id);
     CompletableFuture<Optional<ApiKeyDO>> getByKey(String key);
 }

--- a/dal/persistence/src/main/java/com/nexblocks/authguard/dal/persistence/ApplicationsRepository.java
+++ b/dal/persistence/src/main/java/com/nexblocks/authguard/dal/persistence/ApplicationsRepository.java
@@ -9,5 +9,5 @@ import java.util.concurrent.CompletableFuture;
 
 public interface ApplicationsRepository extends Repository<AppDO> {
     CompletableFuture<Optional<AppDO>> getByExternalId(String externalId);
-    CompletableFuture<List<AppDO>> getAllForAccount(String accountId);
+    CompletableFuture<List<AppDO>> getAllForAccount(long accountId);
 }

--- a/dal/persistence/src/main/java/com/nexblocks/authguard/dal/persistence/ClientsRepository.java
+++ b/dal/persistence/src/main/java/com/nexblocks/authguard/dal/persistence/ClientsRepository.java
@@ -9,7 +9,7 @@ import java.util.concurrent.CompletableFuture;
 
 public interface ClientsRepository extends Repository<ClientDO> {
     CompletableFuture<Optional<ClientDO>> getByExternalId(String externalId);
-    CompletableFuture<List<ClientDO>> getAllForAccount(String accountId);
+    CompletableFuture<List<ClientDO>> getAllForAccount(long accountId);
     CompletableFuture<List<ClientDO>> getByType(String externalId);
     CompletableFuture<List<ClientDO>> getByDomain(String externalId);
 }

--- a/dal/persistence/src/main/java/com/nexblocks/authguard/dal/persistence/CredentialsAuditRepository.java
+++ b/dal/persistence/src/main/java/com/nexblocks/authguard/dal/persistence/CredentialsAuditRepository.java
@@ -9,5 +9,5 @@ import java.util.concurrent.CompletableFuture;
 
 public interface CredentialsAuditRepository
         extends IndelibleRecordRepository<CredentialsAuditDO>, ImmutableRecordRepository<CredentialsAuditDO> {
-    CompletableFuture<List<CredentialsAuditDO>> findByCredentialsId(String credentialsId);
+    CompletableFuture<List<CredentialsAuditDO>> findByCredentialsId(long credentialsId);
 }

--- a/dal/persistence/src/main/java/com/nexblocks/authguard/dal/persistence/ExchangeAttemptsRepository.java
+++ b/dal/persistence/src/main/java/com/nexblocks/authguard/dal/persistence/ExchangeAttemptsRepository.java
@@ -10,11 +10,11 @@ import java.util.concurrent.CompletableFuture;
 
 public interface ExchangeAttemptsRepository
         extends ImmutableRecordRepository<ExchangeAttemptDO>, IndelibleRecordRepository<ExchangeAttemptDO> {
-    CompletableFuture<Collection<ExchangeAttemptDO>> findByEntity(String entityId);
+    CompletableFuture<Collection<ExchangeAttemptDO>> findByEntity(long entityId);
 
-    CompletableFuture<Collection<ExchangeAttemptDO>> findByEntityAndTimestamp(String entityId, Instant fromTimestamp);
+    CompletableFuture<Collection<ExchangeAttemptDO>> findByEntityAndTimestamp(long entityId, Instant fromTimestamp);
 
-    CompletableFuture<Collection<ExchangeAttemptDO>> findByEntityAndTimestampAndExchange(String entityId,
+    CompletableFuture<Collection<ExchangeAttemptDO>> findByEntityAndTimestampAndExchange(long entityId,
                                                                                          Instant fromTimestamp,
                                                                                          String fromExchange);
 }

--- a/jwt/src/main/java/com/nexblocks/authguard/jwt/AccessTokenProvider.java
+++ b/jwt/src/main/java/com/nexblocks/authguard/jwt/AccessTokenProvider.java
@@ -146,7 +146,7 @@ public class AccessTokenProvider implements AuthProvider {
                 .orElseThrow(() -> new ServiceAuthorizationException(ErrorCode.INVALID_TOKEN, "Invalid refresh token"));
     }
 
-    private AccountTokenDO storeRefreshToken(final String accountId, final String refreshToken,
+    private AccountTokenDO storeRefreshToken(final long accountId, final String refreshToken,
                                              final TokenRestrictionsBO tokenRestrictions,
                                              final TokenOptions tokenOptions) {
         final AccountTokenDO.AccountTokenDOBuilder<?, ?> accountToken = AccountTokenDO.builder()

--- a/jwt/src/main/java/com/nexblocks/authguard/jwt/ApiTokenVerifier.java
+++ b/jwt/src/main/java/com/nexblocks/authguard/jwt/ApiTokenVerifier.java
@@ -23,7 +23,7 @@ public class ApiTokenVerifier implements AuthVerifier {
     }
 
     @Override
-    public Either<Exception, String> verifyAccountToken(final String token) {
+    public Either<Exception, Long> verifyAccountToken(final String token) {
         return jwtVerifier.verifyAccountToken(token);
     }
 }

--- a/jwt/src/main/java/com/nexblocks/authguard/jwt/BasicJtiProvider.java
+++ b/jwt/src/main/java/com/nexblocks/authguard/jwt/BasicJtiProvider.java
@@ -22,7 +22,7 @@ public class BasicJtiProvider implements JtiProvider {
     public String next() {
         final AccountTokenDO persistedToken = accountTokensRepository.save(AccountTokenDO.builder()
                 .id(ID.generate())
-                .token(ID.generate())
+                .token(ID.generateSimplifiedUuid())
                 .build())
                 .join();
 

--- a/jwt/src/main/java/com/nexblocks/authguard/jwt/JwtApiKeyProvider.java
+++ b/jwt/src/main/java/com/nexblocks/authguard/jwt/JwtApiKeyProvider.java
@@ -89,7 +89,7 @@ public class JwtApiKeyProvider implements AuthProvider {
         final String keyId = jti.next();
 
         final JWTCreator.Builder jwtBuilder = JWT.create()
-                .withSubject(app.getId())
+                .withSubject("" + app.getId())
                 .withJWTId(keyId)
                 .withClaim("type", "API");
 
@@ -124,7 +124,7 @@ public class JwtApiKeyProvider implements AuthProvider {
         final String keyId = jti.next();
 
         final JWTCreator.Builder jwtBuilder = JWT.create()
-                .withSubject(client.getId())
+                .withSubject("" + client.getId())
                 .withJWTId(keyId)
                 .withClaim("type", "API")
                 .withClaim("clientType", client.getClientType().name());

--- a/jwt/src/main/java/com/nexblocks/authguard/jwt/JwtGenerator.java
+++ b/jwt/src/main/java/com/nexblocks/authguard/jwt/JwtGenerator.java
@@ -32,7 +32,7 @@ public class JwtGenerator {
 
         return JWT.create()
                 .withIssuer(jwtConfig.getIssuer())
-                .withSubject(account.getId())
+                .withSubject("" + account.getId())
                 // TODO properly handle timezones
                 .withIssuedAt(Date.from(now.toInstant(ZoneId.systemDefault().getRules().getOffset(now))))
                 .withExpiresAt(Date.from(exp.toInstant(ZoneId.systemDefault().getRules().getOffset(now))));

--- a/jwt/src/main/java/com/nexblocks/authguard/jwt/exchange/AccountsServiceAdapter.java
+++ b/jwt/src/main/java/com/nexblocks/authguard/jwt/exchange/AccountsServiceAdapter.java
@@ -9,7 +9,7 @@ import io.vavr.control.Either;
 
 /**
  * An adapter class to wrap {@link AccountsService} to
- * provide a difference interface, more suitable for
+ * provide a different interface, more suitable for
  * its use here.
  */
 public class AccountsServiceAdapter {
@@ -20,7 +20,7 @@ public class AccountsServiceAdapter {
         this.accountsService = accountsService;
     }
 
-    public Either<Exception, AccountBO> getAccount(final String accountId) {
+    public Either<Exception, AccountBO> getAccount(final long accountId) {
         return accountsService.getById(accountId)
                 .<Either<Exception, AccountBO>>map(Either::right)
                 .orElseGet(() -> Either.left(new ServiceAuthorizationException(ErrorCode.ACCOUNT_DOES_NOT_EXIST,

--- a/jwt/src/main/java/com/nexblocks/authguard/jwt/exchange/AuthorizationCodeToOidc.java
+++ b/jwt/src/main/java/com/nexblocks/authguard/jwt/exchange/AuthorizationCodeToOidc.java
@@ -1,5 +1,6 @@
 package com.nexblocks.authguard.jwt.exchange;
 
+import com.google.inject.Inject;
 import com.nexblocks.authguard.dal.model.AccountTokenDO;
 import com.nexblocks.authguard.jwt.OpenIdConnectTokenProvider;
 import com.nexblocks.authguard.jwt.oauth.AuthorizationCodeVerifier;
@@ -18,6 +19,7 @@ public class AuthorizationCodeToOidc implements Exchange {
     private final OpenIdConnectTokenProvider openIdConnectTokenProvider;
     private final ServiceMapper serviceMapper;
 
+    @Inject
     public AuthorizationCodeToOidc(final AccountsServiceAdapter accountsServiceAdapter,
                                    final AuthorizationCodeVerifier authorizationCodeVerifier,
                                    final OpenIdConnectTokenProvider openIdConnectTokenProvider,

--- a/jwt/src/main/java/com/nexblocks/authguard/jwt/exchange/RefreshToAccessToken.java
+++ b/jwt/src/main/java/com/nexblocks/authguard/jwt/exchange/RefreshToAccessToken.java
@@ -91,13 +91,13 @@ public class RefreshToAccessToken implements Exchange {
     }
 
     private Either<Exception, AuthResponseBO> generateNewTokens(final AccountTokenDO accountToken) {
-        String accountId = accountToken.getAssociatedAccountId();
+        long accountId = accountToken.getAssociatedAccountId();
         TokenRestrictionsBO tokenRestrictions = serviceMapper.toBO(accountToken.getTokenRestrictions());
 
         return getAccount(accountId, accountToken).map(account -> accessTokenProvider.generateToken(account, tokenRestrictions));
     }
 
-    private Either<Exception, AccountBO> getAccount(final String accountId, final AccountTokenDO accountToken) {
+    private Either<Exception, AccountBO> getAccount(final long accountId, final AccountTokenDO accountToken) {
         return accountsService.getById(accountId)
                 .<Either<Exception, AccountBO>>map(Either::right)
                 .orElseGet(() -> {

--- a/jwt/src/main/java/com/nexblocks/authguard/jwt/exchange/apikeys/JwtApiKeyExchange.java
+++ b/jwt/src/main/java/com/nexblocks/authguard/jwt/exchange/apikeys/JwtApiKeyExchange.java
@@ -40,7 +40,7 @@ public class JwtApiKeyExchange implements ApiKeyExchange {
     }
 
     @Override
-    public CompletableFuture<Optional<String>> verifyAndGetAppId(final String apiKey) {
+    public CompletableFuture<Optional<Long>> verifyAndGetAppId(final String apiKey) {
         return CompletableFuture.supplyAsync(() ->
                 tokenVerifier.verifyAccountToken(apiKey)
                         .map(Optional::of)
@@ -54,7 +54,7 @@ public class JwtApiKeyExchange implements ApiKeyExchange {
     }
 
     @Override
-    public CompletableFuture<Optional<String>> verifyAndGetClientId(String apiKey) {
+    public CompletableFuture<Optional<Long>> verifyAndGetClientId(String apiKey) {
         return verifyAndGetAppId(apiKey);
     }
 }

--- a/jwt/src/main/java/com/nexblocks/authguard/jwt/oauth/AuthorizationCodeVerifier.java
+++ b/jwt/src/main/java/com/nexblocks/authguard/jwt/oauth/AuthorizationCodeVerifier.java
@@ -20,7 +20,7 @@ public class AuthorizationCodeVerifier implements AuthVerifier {
     }
 
     @Override
-    public Either<Exception, String> verifyAccountToken(final String token) {
+    public Either<Exception, Long> verifyAccountToken(final String token) {
         return verifyAndGetAccountToken(token)
                 .map(AccountTokenDO::getAssociatedAccountId);
     }

--- a/jwt/src/main/java/com/nexblocks/authguard/jwt/oauth/TokensResponse.java
+++ b/jwt/src/main/java/com/nexblocks/authguard/jwt/oauth/TokensResponse.java
@@ -14,7 +14,7 @@ public class TokensResponse {
     @JsonProperty("refresh_token")
     private String refreshToken;
 
-    private String accountId;
+    private long accountId;
 
     public String getIdToken() {
         return idToken;
@@ -43,11 +43,11 @@ public class TokensResponse {
         return this;
     }
 
-    public String getAccountId() {
+    public long getAccountId() {
         return accountId;
     }
 
-    public TokensResponse setAccountId(final String accountId) {
+    public TokensResponse setAccountId(final long accountId) {
         this.accountId = accountId;
         return this;
     }

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/AccessTokenProviderTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/AccessTokenProviderTest.java
@@ -265,7 +265,7 @@ class AccessTokenProviderTest {
         final AccessTokenProvider accessTokenProvider = newProviderInstance(jwtConfig(), strategyConfig());
 
         final String refreshToken = "refresh";
-        final String accountId = "account";
+        final long accountId = 101;
         final AuthRequestBO deleteRequest = AuthRequestBO.builder().token(refreshToken).build();
 
         Mockito.when(accountTokensRepository.deleteToken(refreshToken))
@@ -302,10 +302,10 @@ class AccessTokenProviderTest {
                 .isInstanceOf(ServiceAuthorizationException.class);
     }
 
-    private void verifyToken(final String token, final String subject, final String jti, final List<String> permissions) {
+    private void verifyToken(final String token, final long subject, final String jti, final List<String> permissions) {
         final Verification verifier = JWT.require(JwtConfigParser.parseAlgorithm(ALGORITHM, null, KEY))
                 .withIssuer(ISSUER)
-                .withSubject(subject);
+                .withSubject("" + subject);
 
         if (jti != null) {
             verifier.withJWTId(jti);

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/IdTokenProviderTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/IdTokenProviderTest.java
@@ -94,11 +94,11 @@ class IdTokenProviderTest {
         assertThat(tokens.getToken()).isNotEqualTo(tokens.getRefreshToken());
     }
 
-    private void verifyToken(final String token, final String subject, final String jti,
+    private void verifyToken(final String token, final long subject, final String jti,
                              final List<PermissionBO> permissions, final List<String> scopes) {
         final Verification verifier = JWT.require(JwtConfigParser.parseAlgorithm(ALGORITHM, null, KEY))
                 .withIssuer(ISSUER)
-                .withSubject(subject);
+                .withSubject("" + subject);
 
         if (jti != null) {
             verifier.withJWTId(jti);

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/JwtApiKeyProviderTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/JwtApiKeyProviderTest.java
@@ -129,9 +129,9 @@ class JwtApiKeyProviderTest {
                 Instant.now().plusSeconds(6));
     }
 
-    private void verifyToken(final String token, final String subject, final String jti) {
+    private void verifyToken(final String token, final long subject, final String jti) {
         final JWTVerifier verifier = JWT.require(JwtConfigParser.parseAlgorithm(ALGORITHM, null, KEY))
-                .withSubject(subject)
+                .withSubject("" + subject)
                 .withJWTId(jti)
                 .build();
 
@@ -142,10 +142,10 @@ class JwtApiKeyProviderTest {
     }
 
     private DecodedJWT verifyAndGetDecodedToken(final String token,
-                                                final String subject,
+                                                final long subject,
                                                 final String jti) {
         final JWTVerifier verifier = JWT.require(JwtConfigParser.parseAlgorithm(ALGORITHM, null, KEY))
-                .withSubject(subject)
+                .withSubject("" + subject)
                 .withJWTId(jti)
                 .build();
 

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/JwtSignatureAlgorithmsTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/JwtSignatureAlgorithmsTest.java
@@ -54,7 +54,7 @@ public class JwtSignatureAlgorithmsTest {
         final JwtGenerator jwtGenerator = new JwtGenerator(config);
 
         final AccountBO account = AccountBO.builder()
-                .id("id")
+                .id(101)
                 .build();
 
         final JWTCreator.Builder tokenBuilder = jwtGenerator.generateUnsignedToken(account, Duration.ofMinutes(5));

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/JwtTokenVerifierTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/JwtTokenVerifierTest.java
@@ -172,7 +172,7 @@ class JwtTokenVerifierTest {
         assertThat(jwtTokenVerifier.verify(maliciousToken)).isEmpty();
     }
 
-    private void verifyToken(final DecodedJWT decodedJWT, final String subject, final String jti, final List<PermissionBO> permissions,
+    private void verifyToken(final DecodedJWT decodedJWT, final long subject, final String jti, final List<PermissionBO> permissions,
                              final List<String> scopes) {
         final JWTVerifier verifier = JWT.require(JwtConfigParser.parseAlgorithm(ALGORITHM, null, KEY))
                 .build();
@@ -180,7 +180,7 @@ class JwtTokenVerifierTest {
         verifier.verify(decodedJWT);
 
         assertThat(decodedJWT.getIssuer()).isEqualTo(ISSUER);
-        assertThat(decodedJWT.getSubject()).isEqualTo(subject);
+        assertThat(decodedJWT.getSubject()).isEqualTo("" + subject);
 
         if (jti != null) {
             assertThat(decodedJWT.getId()).isEqualTo(jti);

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/OpenIdConnectTokenProviderTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/OpenIdConnectTokenProviderTest.java
@@ -24,7 +24,7 @@ class OpenIdConnectTokenProviderTest {
 
     @Test
     void generateToken() {
-        final AccountBO account = AccountBO.builder().id("account").build();
+        final AccountBO account = AccountBO.builder().id(101).build();
 
         final AuthResponseBO accessTokenResponse = AuthResponseBO.builder()
                 .token("access token")
@@ -59,7 +59,7 @@ class OpenIdConnectTokenProviderTest {
 
     @Test
     void generateTokenWithRestrictions() {
-        final AccountBO account = AccountBO.builder().id("account").build();
+        final AccountBO account = AccountBO.builder().id(101).build();
 
         final TokenRestrictionsBO restrictions = TokenRestrictionsBO.builder()
                 .addPermissions("permission")

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/exchange/AuthorizationCodeToOidcTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/exchange/AuthorizationCodeToOidcTest.java
@@ -53,11 +53,11 @@ class AuthorizationCodeToOidcTest {
                 .build();
 
         final AccountTokenDO accountToken = AccountTokenDO.builder()
-                .associatedAccountId("account")
+                .associatedAccountId(101)
                 .build();
 
         final AccountBO account = AccountBO.builder()
-                .id("account")
+                .id(101)
                 .build();
 
         final AuthResponseBO authResponse = AuthResponseBO.builder()
@@ -86,7 +86,7 @@ class AuthorizationCodeToOidcTest {
                 .build();
 
         final AccountTokenDO accountToken = AccountTokenDO.builder()
-                .associatedAccountId("account")
+                .associatedAccountId(101)
                 .tokenRestrictions(TokenRestrictionsDO.builder()
                         .scopes(Collections.emptySet())
                         .permissions(new HashSet<>(Arrays.asList("perm-1", "perm-2")))
@@ -94,7 +94,7 @@ class AuthorizationCodeToOidcTest {
                 .build();
 
         final AccountBO account = AccountBO.builder()
-                .id("account")
+                .id(101)
                 .build();
 
         final AuthResponseBO authResponse = AuthResponseBO.builder()

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/exchange/BasicToOIdCTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/exchange/BasicToOIdCTest.java
@@ -33,7 +33,7 @@ class BasicToOIdCTest {
 
     @Test
     void exchange() {
-        final AccountBO account = AccountBO.builder().id("account").build();
+        final AccountBO account = AccountBO.builder().id(101).build();
 
         final AuthRequestBO authRequest = AuthRequestBO.builder()
                 .identifier("username")

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/exchange/RefreshToAccessTokenTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/exchange/RefreshToAccessTokenTest.java
@@ -45,7 +45,7 @@ class RefreshToAccessTokenTest {
     @Test
     void exchange() {
         // data
-        final String accountId = "account";
+        final long accountId = 101;
         final String refreshToken = "refresh_token";
 
         final AuthRequestBO authRequest = AuthRequestBO.builder()
@@ -90,7 +90,7 @@ class RefreshToAccessTokenTest {
     @Test
     void exchangeWithRestrictions() {
         // data
-        final String accountId = "account";
+        final long accountId = 101;
         final String refreshToken = "refresh_token";
         final String restrictionPermission = "permission.read";
 
@@ -141,7 +141,7 @@ class RefreshToAccessTokenTest {
     @Test
     void exchangeExpiredToken() {
         // data
-        final String accountId = "account";
+        final long accountId = 101;
         final String refreshToken = "refresh_token";
 
         final AuthRequestBO authRequest = AuthRequestBO.builder()
@@ -171,7 +171,7 @@ class RefreshToAccessTokenTest {
     @Test
     void exchangeNoAccount() {
         // data
-        final String accountId = "account";
+        final long accountId = 101;
         final String refreshToken = "refresh_token";
 
         final AuthRequestBO authRequest = AuthRequestBO.builder()
@@ -225,7 +225,7 @@ class RefreshToAccessTokenTest {
     @Test
     void exchangeWithTokenOptionChecks() {
         // data
-        final String accountId = "account";
+        final long accountId = 101;
         final String refreshToken = "refresh_token";
 
         final AuthRequestBO authRequest = AuthRequestBO.builder()
@@ -280,7 +280,7 @@ class RefreshToAccessTokenTest {
     @Test
     void exchangeWithMismatchedTokenOptions() {
         // data
-        final String accountId = "account";
+        final long accountId = 101;
         final String refreshToken = "refresh_token";
 
         final AuthRequestBO authRequest = AuthRequestBO.builder()

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/exchange/apikeys/JwtApiKeyExchangeTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/exchange/apikeys/JwtApiKeyExchangeTest.java
@@ -29,7 +29,7 @@ class JwtApiKeyExchangeTest {
     @Test
     void generateKeyWithoutExpiry() {
         final AppBO app = AppBO.builder()
-                .id("appId")
+                .id(101)
                 .build();
 
         final AuthResponseBO expected = AuthResponseBO.builder()
@@ -47,7 +47,7 @@ class JwtApiKeyExchangeTest {
     @Test
     void generateKeyWithExpiry() {
         final AppBO app = AppBO.builder()
-                .id("appId")
+                .id(101)
                 .build();
         final Instant expiresAt = Instant.now().plusSeconds(10);
 

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/oauth/AuthorizationCodeProviderTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/oauth/AuthorizationCodeProviderTest.java
@@ -35,7 +35,7 @@ class AuthorizationCodeProviderTest {
                 new AuthorizationCodeProvider(accountTokensRepository, new ServiceMapperImpl(), config());
 
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .build();
 
         final AuthResponseBO tokens = authorizationCodeProvider.generateToken(account);

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/oauth/AuthorizationCodeVerifierTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/oauth/AuthorizationCodeVerifierTest.java
@@ -22,7 +22,7 @@ class AuthorizationCodeVerifierTest {
         final AccountTokensRepository accountTokensRepository = Mockito.mock(AccountTokensRepository.class);
         final AuthorizationCodeVerifier authorizationCodeVerifier = new AuthorizationCodeVerifier(accountTokensRepository);
 
-        final String accountId = "account-id";
+        final long accountId = 101;
         final String authorizationCode = "authorization-code";
 
         final AccountTokenDO accountToken = AccountTokenDO.builder()
@@ -47,7 +47,7 @@ class AuthorizationCodeVerifierTest {
         Mockito.when(accountTokensRepository.getByToken(authorizationCode))
                 .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
-        final Either<Exception, String> result = authorizationCodeVerifier.verifyAccountToken(authorizationCode);
+        final Either<Exception, Long> result = authorizationCodeVerifier.verifyAccountToken(authorizationCode);
 
         assertThat(result.isLeft());
         assertThat(result.getLeft()).isInstanceOf(ServiceAuthorizationException.class);
@@ -58,7 +58,7 @@ class AuthorizationCodeVerifierTest {
         final AccountTokensRepository accountTokensRepository = Mockito.mock(AccountTokensRepository.class);
         final AuthorizationCodeVerifier authorizationCodeVerifier = new AuthorizationCodeVerifier(accountTokensRepository);
 
-        final String accountId = "account-id";
+        final long accountId = 101;
         final String authorizationCode = "authorization-code";
 
         final AccountTokenDO accountToken = AccountTokenDO.builder()

--- a/jwt/src/test/java/com/nexblocks/authguard/jwt/oauth/service/OAuthServiceTest.java
+++ b/jwt/src/test/java/com/nexblocks/authguard/jwt/oauth/service/OAuthServiceTest.java
@@ -182,13 +182,13 @@ class OAuthServiceTest {
 
         Mockito.when(accountsService.create(Mockito.any(), Mockito.eq(expectedContext)))
                 .thenAnswer(invocation ->
-                        invocation.getArgument(0, AccountBO.class).withId("1"));
+                        invocation.getArgument(0, AccountBO.class).withId(1));
 
         final TokensResponse actual = oAuthService.exchangeAuthorizationCode("account_test", "random", "code")
                 .join();
         final TokensResponse expected = testIdentityServer.getSuccessResponse();
 
-        expected.setAccountId("1");
+        expected.setAccountId(1);
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -206,13 +206,13 @@ class OAuthServiceTest {
                 });
 
         Mockito.when(accountsService.getByExternalId("1"))
-                .thenReturn(Optional.of(AccountBO.builder().id("1").build()));
+                .thenReturn(Optional.of(AccountBO.builder().id(1).build()));
 
         final TokensResponse actual = oAuthService.exchangeAuthorizationCode("account_test", "random", "code")
                 .join();
         final TokensResponse expected = testIdentityServer.getSuccessResponse();
 
-        expected.setAccountId("1");
+        expected.setAccountId(1);
 
         assertThat(actual).isEqualTo(expected);
     }

--- a/ldap/src/main/java/com/nexblocks/authguard/ldap/LdapAccountMapper.java
+++ b/ldap/src/main/java/com/nexblocks/authguard/ldap/LdapAccountMapper.java
@@ -32,7 +32,8 @@ public class LdapAccountMapper {
     }
 
     public AccountBO.Builder mapAttributes(final Map<String, String[]> attributes, final Map<String, String> fieldMappings) {
-        final AccountBO.Builder builder = AccountBO.builder();
+        final AccountBO.Builder builder = AccountBO.builder()
+                .id(0); // external accounts only have an external ID
 
         attributes.forEach((key, value) -> {
             final String mappedField = fieldMappings.get(key);
@@ -40,7 +41,7 @@ public class LdapAccountMapper {
             if (mappedField != null) {
                 switch (mappedField) {
                     case "id":
-                        builder.id(value[0]);
+                        builder.externalId(value[0]);
                         break;
 
                     case "roles":

--- a/plugins/account-lock/src/test/java/com/nexblocks/authguard/extensions/AccountLockerTest.java
+++ b/plugins/account-lock/src/test/java/com/nexblocks/authguard/extensions/AccountLockerTest.java
@@ -44,7 +44,7 @@ class AccountLockerTest {
     void onMessageNoLock() {
         // data
         final AuthMessage authMessage = AuthMessage.success("basic", "session",
-                EntityType.ACCOUNT, "account");
+                EntityType.ACCOUNT, 101L);
 
         final Message<Object> message = Message.builder()
                 .eventType(EventType.AUTHENTICATION)
@@ -54,7 +54,7 @@ class AccountLockerTest {
                 .build();
 
         // mocks
-        Mockito.when(exchangeAttemptsRepository.findByEntityAndTimestamp(Mockito.any(), Mockito.any()))
+        Mockito.when(exchangeAttemptsRepository.findByEntityAndTimestamp(Mockito.anyLong(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
 
         // call
@@ -64,7 +64,7 @@ class AccountLockerTest {
         final ArgumentCaptor<Instant> timeArgumentCaptor = ArgumentCaptor.forClass(Instant.class);
 
         Mockito.verify(exchangeAttemptsRepository)
-                .findByEntityAndTimestamp(Mockito.eq("account"), timeArgumentCaptor.capture());
+                .findByEntityAndTimestamp(Mockito.eq(101L), timeArgumentCaptor.capture());
 
         assertThat(timeArgumentCaptor.getValue()).isBetween(
                 Instant.now()
@@ -82,7 +82,7 @@ class AccountLockerTest {
     void onMessageLock() {
         // data
         final AuthMessage authMessage = AuthMessage.success("basic", "session",
-                EntityType.ACCOUNT, "account");
+                EntityType.ACCOUNT, 101L);
 
         final Message<Object> message = Message.builder()
                 .eventType(EventType.AUTHENTICATION)
@@ -92,7 +92,7 @@ class AccountLockerTest {
                 .build();
 
         // mocks
-        Mockito.when(exchangeAttemptsRepository.findByEntityAndTimestamp(Mockito.any(), Mockito.any()))
+        Mockito.when(exchangeAttemptsRepository.findByEntityAndTimestamp(Mockito.anyLong(), Mockito.any()))
                 .thenReturn(CompletableFuture.completedFuture(Arrays.asList(
                         ExchangeAttemptDO.builder().build(),
                         ExchangeAttemptDO.builder().build(),
@@ -107,7 +107,7 @@ class AccountLockerTest {
         final ArgumentCaptor<AccountLockBO> accountLockArgumentCaptor = ArgumentCaptor.forClass(AccountLockBO.class);
 
         Mockito.verify(exchangeAttemptsRepository)
-                .findByEntityAndTimestamp(Mockito.eq("account"), timeArgumentCaptor.capture());
+                .findByEntityAndTimestamp(Mockito.eq(101L), timeArgumentCaptor.capture());
 
         assertThat(timeArgumentCaptor.getValue()).isBetween(
                 Instant.now()
@@ -135,7 +135,7 @@ class AccountLockerTest {
     void onMessageNotAuth() {
         // data
         final AuthMessage authMessage = AuthMessage.success("basic", "session",
-                EntityType.ACCOUNT, "account");
+                EntityType.ACCOUNT, 101L);
 
         final Message<Object> message = Message.builder()
                 .eventType(EventType.EMAIL_VERIFICATION)
@@ -155,7 +155,7 @@ class AccountLockerTest {
     void onMessageAuthWrongBodyType() {
         // data
         final AuthMessage authMessage = AuthMessage.success("basic", "session",
-                EntityType.ACCOUNT, "account");
+                EntityType.ACCOUNT, 101L);
 
         final Message<Object> message = Message.builder()
                 .eventType(EventType.AUTHENTICATION)
@@ -175,7 +175,7 @@ class AccountLockerTest {
     void onMessageAuthNotAccount() {
         // data
         final AuthMessage authMessage = AuthMessage.success("basic", "session",
-                EntityType.APPLICATION, "account");
+                EntityType.APPLICATION, 101L);
 
         final Message<Object> message = Message.builder()
                 .eventType(EventType.AUTHENTICATION)

--- a/plugins/verification-plugin/src/test/java/com/nexblocks/authguard/extensions/verification/VerificationSubscriberTest.java
+++ b/plugins/verification-plugin/src/test/java/com/nexblocks/authguard/extensions/verification/VerificationSubscriberTest.java
@@ -44,7 +44,7 @@ class VerificationSubscriberTest {
     @Test
     void onEmailVerificationMessage() {
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .email(AccountEmailBO.builder()
                         .email("unverified")
                         .verified(false)

--- a/rest/src/main/java/com/nexblocks/authguard/rest/routes/ActionTokensRoute.java
+++ b/rest/src/main/java/com/nexblocks/authguard/rest/routes/ActionTokensRoute.java
@@ -15,6 +15,7 @@ import com.nexblocks.authguard.service.exceptions.ServiceException;
 import com.nexblocks.authguard.service.model.ActionTokenBO;
 import com.nexblocks.authguard.service.model.AuthRequestBO;
 import com.nexblocks.authguard.service.model.AuthResponseBO;
+import io.javalin.core.validation.Validator;
 import io.javalin.http.Context;
 import io.vavr.control.Try;
 
@@ -38,7 +39,11 @@ public class ActionTokensRoute extends ActionTokensApi {
 
     @Override
     public void createOtp(final Context context) {
-        final String accountId = context.queryParam("accountId");
+        final Validator<Long> accountId = context.pathParam("id", Long.class);
+
+        if (!accountId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
 
         if (accountId == null) {
             throw new RequestValidationException(Collections.singletonList(
@@ -46,7 +51,7 @@ public class ActionTokensRoute extends ActionTokensApi {
             ));
         }
 
-        final Try<AuthResponseBO> result = actionTokenService.generateOtp(accountId);
+        final Try<AuthResponseBO> result = actionTokenService.generateOtp(accountId.get());
 
         if (result.isFailure()) {
             throw (ServiceException) result.getCause();

--- a/rest/src/main/java/com/nexblocks/authguard/rest/routes/ApiKeysRoute.java
+++ b/rest/src/main/java/com/nexblocks/authguard/rest/routes/ApiKeysRoute.java
@@ -5,16 +5,21 @@ import com.nexblocks.authguard.api.dto.entities.ApiKeyDTO;
 import com.nexblocks.authguard.api.dto.entities.Error;
 import com.nexblocks.authguard.api.dto.requests.ApiKeyRequestDTO;
 import com.nexblocks.authguard.api.dto.requests.ApiKeyVerificationRequestDTO;
+import com.nexblocks.authguard.api.dto.validation.violations.Violation;
+import com.nexblocks.authguard.api.dto.validation.violations.ViolationType;
 import com.nexblocks.authguard.api.routes.ApiKeysApi;
+import com.nexblocks.authguard.rest.exceptions.RequestValidationException;
 import com.nexblocks.authguard.rest.mappers.RestMapper;
 import com.nexblocks.authguard.rest.util.BodyHandler;
 import com.nexblocks.authguard.service.ApiKeysService;
 import com.nexblocks.authguard.service.exceptions.codes.ErrorCode;
 import com.nexblocks.authguard.service.model.ApiKeyBO;
 import com.nexblocks.authguard.service.model.AppBO;
+import io.javalin.core.validation.Validator;
 import io.javalin.http.Context;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Optional;
 
 public class ApiKeysRoute extends ApiKeysApi {
@@ -49,9 +54,13 @@ public class ApiKeysRoute extends ApiKeysApi {
 
     @Override
     public void getById(final Context context) {
-        final String apiKeyId = context.pathParam("id");
+        final Validator<Long> apiKeyId = context.pathParam("id", Long.class);
 
-        final Optional<ApiKeyDTO> apiKey = apiKeysService.getById(apiKeyId)
+        if (!apiKeyId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final Optional<ApiKeyDTO> apiKey = apiKeysService.getById(apiKeyId.get())
                 .map(restMapper::toDTO);
 
         if (apiKey.isPresent()) {
@@ -79,9 +88,13 @@ public class ApiKeysRoute extends ApiKeysApi {
 
     @Override
     public void deleteById(final Context context) {
-        final String apiKeyId = context.pathParam("id");
+        final Validator<Long> apiKeyId = context.pathParam("id", Long.class);
 
-        final Optional<ApiKeyDTO> apiKey = apiKeysService.delete(apiKeyId)
+        if (!apiKeyId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final Optional<ApiKeyDTO> apiKey = apiKeysService.delete(apiKeyId.get())
                 .map(restMapper::toDTO);
 
         if (apiKey.isPresent()) {

--- a/rest/src/main/java/com/nexblocks/authguard/rest/routes/ApplicationsRoute.java
+++ b/rest/src/main/java/com/nexblocks/authguard/rest/routes/ApplicationsRoute.java
@@ -5,7 +5,10 @@ import com.nexblocks.authguard.api.dto.entities.ApiKeyDTO;
 import com.nexblocks.authguard.api.dto.entities.AppDTO;
 import com.nexblocks.authguard.api.dto.entities.Error;
 import com.nexblocks.authguard.api.dto.requests.CreateAppRequestDTO;
+import com.nexblocks.authguard.api.dto.validation.violations.Violation;
+import com.nexblocks.authguard.api.dto.validation.violations.ViolationType;
 import com.nexblocks.authguard.api.routes.ApplicationsApi;
+import com.nexblocks.authguard.rest.exceptions.RequestValidationException;
 import com.nexblocks.authguard.rest.mappers.RestJsonMapper;
 import com.nexblocks.authguard.rest.mappers.RestMapper;
 import com.nexblocks.authguard.rest.util.BodyHandler;
@@ -13,8 +16,10 @@ import com.nexblocks.authguard.rest.util.IdempotencyHeader;
 import com.nexblocks.authguard.service.ApiKeysService;
 import com.nexblocks.authguard.service.ApplicationsService;
 import com.nexblocks.authguard.service.model.RequestContextBO;
+import io.javalin.core.validation.Validator;
 import io.javalin.http.Context;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -59,9 +64,13 @@ public class ApplicationsRoute extends ApplicationsApi {
     }
 
     public void getById(final Context context) {
-        final String applicationId = context.pathParam("id");
+        final Validator<Long> applicationId = context.pathParam("id", Long.class);
 
-        final Optional<AppDTO> application = applicationsService.getById(applicationId)
+        if (!applicationId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final Optional<AppDTO> application = applicationsService.getById(applicationId.get())
                 .map(restMapper::toDTO);
 
         if (application.isPresent()) {
@@ -72,9 +81,13 @@ public class ApplicationsRoute extends ApplicationsApi {
     }
 
     public void getByExternalId(final Context context) {
-        final String applicationId = context.pathParam("id");
+        final Validator<Long> applicationId = context.pathParam("id", Long.class);
 
-        final Optional<AppDTO> application = applicationsService.getById(applicationId)
+        if (!applicationId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final Optional<AppDTO> application = applicationsService.getById(applicationId.get())
                 .map(restMapper::toDTO);
 
         if (application.isPresent()) {
@@ -100,9 +113,13 @@ public class ApplicationsRoute extends ApplicationsApi {
     }
 
     public void deleteById(final Context context) {
-        final String applicationId = context.pathParam("id");
+        final Validator<Long> applicationId = context.pathParam("id", Long.class);
 
-        final Optional<AppDTO> application = applicationsService.delete(applicationId)
+        if (!applicationId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final Optional<AppDTO> application = applicationsService.delete(applicationId.get())
                 .map(restMapper::toDTO);
 
         if (application.isPresent()) {
@@ -113,9 +130,13 @@ public class ApplicationsRoute extends ApplicationsApi {
     }
 
     public void activate(final Context context) {
-        final String applicationId = context.pathParam("id");
+        final Validator<Long> applicationId = context.pathParam("id", Long.class);
 
-        final Optional<AppDTO> application = applicationsService.activate(applicationId)
+        if (!applicationId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final Optional<AppDTO> application = applicationsService.activate(applicationId.get())
                 .map(restMapper::toDTO);
 
         if (application.isPresent()) {
@@ -126,9 +147,13 @@ public class ApplicationsRoute extends ApplicationsApi {
     }
 
     public void deactivate(final Context context) {
-        final String applicationId = context.pathParam("id");
+        final Validator<Long> applicationId = context.pathParam("id", Long.class);
 
-        final Optional<AppDTO> application = applicationsService.deactivate(applicationId)
+        if (!applicationId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final Optional<AppDTO> application = applicationsService.deactivate(applicationId.get())
                 .map(restMapper::toDTO);
 
         if (application.isPresent()) {
@@ -140,9 +165,13 @@ public class ApplicationsRoute extends ApplicationsApi {
 
     @Override
     public void getApiKeys(final Context context) {
-        final String applicationId = context.pathParam("id");
+        final Validator<Long> applicationId = context.pathParam("id", Long.class);
 
-        final List<ApiKeyDTO> keys = apiKeysService.getByAppId(applicationId)
+        if (!applicationId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final List<ApiKeyDTO> keys = apiKeysService.getByAppId(applicationId.get())
                 .stream()
                 .map(restMapper::toDTO)
                 .collect(Collectors.toList());

--- a/rest/src/main/java/com/nexblocks/authguard/rest/routes/AuthRoute.java
+++ b/rest/src/main/java/com/nexblocks/authguard/rest/routes/AuthRoute.java
@@ -19,6 +19,7 @@ import com.nexblocks.authguard.service.ExchangeAttemptsService;
 import com.nexblocks.authguard.service.ExchangeService;
 import com.nexblocks.authguard.service.exceptions.codes.ErrorCode;
 import com.nexblocks.authguard.service.model.*;
+import io.javalin.core.validation.Validator;
 import io.javalin.http.Context;
 
 import java.time.Instant;
@@ -132,12 +133,12 @@ public class AuthRoute extends AuthApi {
 
     @Override
     public void getExchangeAttempts(final Context context) {
-        final String entityId = context.queryParam("entityId");
+        final Validator<Long> entityId = context.queryParam("entityId", Long.class);
         final Instant fromTimestamp = parseOffsetDateTime(context.queryParam("fromTimestamp"));
         final String fromExchange = context.queryParam("fromExchange");
 
         // take care of checking the parameters
-        if (entityId == null) {
+        if (entityId.getOrNull() == null) {
             context.status(400)
                     .json(new Error(ErrorCode.MISSING_REQUEST_QUERY.getCode(),
                             "Query parameter entityId is required"));
@@ -155,7 +156,7 @@ public class AuthRoute extends AuthApi {
 
         // do the real work
         final ExchangeAttemptsQueryBO query = ExchangeAttemptsQueryBO.builder()
-                .entityId(entityId)
+                .entityId(entityId.get())
                 .fromTimestamp(fromTimestamp)
                 .fromExchange(fromExchange)
                 .build();
@@ -199,7 +200,7 @@ public class AuthRoute extends AuthApi {
                 authRequest = authRequest.withUserAgent(context.userAgent());
             }
 
-            return Optional.of(authRequest.withClientId(client.getId()));
+            return Optional.of(authRequest.withClientId("" + client.getId())); // TODO migrate that to long as well
         }
 
         return Optional.of(authRequest);

--- a/rest/src/main/java/com/nexblocks/authguard/rest/routes/ClientsRoute.java
+++ b/rest/src/main/java/com/nexblocks/authguard/rest/routes/ClientsRoute.java
@@ -5,15 +5,21 @@ import com.nexblocks.authguard.api.dto.entities.ApiKeyDTO;
 import com.nexblocks.authguard.api.dto.entities.ClientDTO;
 import com.nexblocks.authguard.api.dto.entities.Error;
 import com.nexblocks.authguard.api.dto.requests.CreateClientRequestDTO;
+import com.nexblocks.authguard.api.dto.validation.violations.Violation;
+import com.nexblocks.authguard.api.dto.validation.violations.ViolationType;
 import com.nexblocks.authguard.api.routes.ClientsApi;
+import com.nexblocks.authguard.rest.exceptions.RequestValidationException;
 import com.nexblocks.authguard.rest.mappers.RestMapper;
 import com.nexblocks.authguard.rest.util.BodyHandler;
 import com.nexblocks.authguard.rest.util.IdempotencyHeader;
 import com.nexblocks.authguard.service.ApiKeysService;
 import com.nexblocks.authguard.service.ClientsService;
+import com.nexblocks.authguard.service.exceptions.ServiceException;
 import com.nexblocks.authguard.service.model.RequestContextBO;
+import io.javalin.core.validation.Validator;
 import io.javalin.http.Context;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -58,9 +64,13 @@ public class ClientsRoute extends ClientsApi {
     }
 
     public void getById(final Context context) {
-        final String clientId = context.pathParam("id");
+        final Validator<Long> clientId = context.pathParam("id", Long.class);
 
-        final Optional<ClientDTO> client = clientsService.getById(clientId)
+        if (!clientId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final Optional<ClientDTO> client = clientsService.getById(clientId.get())
                 .map(restMapper::toDTO);
 
         if (client.isPresent()) {
@@ -71,9 +81,13 @@ public class ClientsRoute extends ClientsApi {
     }
 
     public void getByExternalId(final Context context) {
-        final String clientId = context.pathParam("id");
+        final Validator<Long> clientId = context.pathParam("id", Long.class);
 
-        final Optional<ClientDTO> client = clientsService.getById(clientId)
+        if (!clientId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final Optional<ClientDTO> client = clientsService.getById(clientId.get())
                 .map(restMapper::toDTO);
 
         if (client.isPresent()) {
@@ -84,9 +98,13 @@ public class ClientsRoute extends ClientsApi {
     }
 
     public void deleteById(final Context context) {
-        final String clientId = context.pathParam("id");
+        final Validator<Long> clientId = context.pathParam("id", Long.class);
 
-        final Optional<ClientDTO> client = clientsService.delete(clientId)
+        if (!clientId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final Optional<ClientDTO> client = clientsService.delete(clientId.get())
                 .map(restMapper::toDTO);
 
         if (client.isPresent()) {
@@ -97,9 +115,13 @@ public class ClientsRoute extends ClientsApi {
     }
 
     public void activate(final Context context) {
-        final String clientId = context.pathParam("id");
+        final Validator<Long> clientId = context.pathParam("id", Long.class);
 
-        final Optional<ClientDTO> client = clientsService.activate(clientId)
+        if (!clientId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final Optional<ClientDTO> client = clientsService.activate(clientId.get())
                 .map(restMapper::toDTO);
 
         if (client.isPresent()) {
@@ -110,9 +132,13 @@ public class ClientsRoute extends ClientsApi {
     }
 
     public void deactivate(final Context context) {
-        final String clientId = context.pathParam("id");
+        final Validator<Long> clientId = context.pathParam("id", Long.class);
 
-        final Optional<ClientDTO> client = clientsService.deactivate(clientId)
+        if (!clientId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final Optional<ClientDTO> client = clientsService.deactivate(clientId.get())
                 .map(restMapper::toDTO);
 
         if (client.isPresent()) {
@@ -124,9 +150,13 @@ public class ClientsRoute extends ClientsApi {
 
     @Override
     public void getApiKeys(final Context context) {
-        final String clientId = context.pathParam("id");
+        final Validator<Long> clientId = context.pathParam("id", Long.class);
 
-        final List<ApiKeyDTO> keys = apiKeysService.getByAppId(clientId)
+        if (!clientId.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        final List<ApiKeyDTO> keys = apiKeysService.getByAppId(clientId.get())
                 .stream()
                 .map(restMapper::toDTO)
                 .collect(Collectors.toList());

--- a/rest/src/main/java/com/nexblocks/authguard/rest/routes/PermissionsRoute.java
+++ b/rest/src/main/java/com/nexblocks/authguard/rest/routes/PermissionsRoute.java
@@ -3,15 +3,20 @@ package com.nexblocks.authguard.rest.routes;
 import com.nexblocks.authguard.api.dto.entities.Error;
 import com.nexblocks.authguard.api.dto.entities.PermissionDTO;
 import com.nexblocks.authguard.api.dto.requests.CreatePermissionRequestDTO;
+import com.nexblocks.authguard.api.dto.validation.violations.Violation;
+import com.nexblocks.authguard.api.dto.validation.violations.ViolationType;
 import com.nexblocks.authguard.api.routes.PermissionsApi;
+import com.nexblocks.authguard.rest.exceptions.RequestValidationException;
 import com.nexblocks.authguard.rest.mappers.RestMapper;
 import com.nexblocks.authguard.rest.util.BodyHandler;
 import com.nexblocks.authguard.service.PermissionsService;
 import com.nexblocks.authguard.service.exceptions.codes.ErrorCode;
 import com.nexblocks.authguard.service.model.PermissionBO;
 import com.google.inject.Inject;
+import io.javalin.core.validation.Validator;
 import io.javalin.http.Context;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,31 +45,39 @@ public class PermissionsRoute extends PermissionsApi {
 
     @Override
     public void getById(final Context context) {
-        final String id = context.pathParam("id");
+        final Validator<Long> id = context.pathParam("id", Long.class);
 
-        permissionsService.getById(id)
+        if (!id.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        permissionsService.getById(id.get())
                 .map(restMapper::toDTO)
                 .ifPresentOrElse(
                         context::json,
                         // or else
                         () -> context.status(404)
                                 .json(new Error(ErrorCode.PERMISSION_DOES_NOT_EXIST.getCode(),
-                                        "No role with ID " + id + " exists"))
+                                        "No role with ID " + id.get() + " exists"))
                 );
     }
 
     @Override
     public void deleteById(final Context context) {
-        final String id = context.pathParam("id");
+        final Validator<Long> id = context.pathParam("id", Long.class);
 
-        permissionsService.delete(id)
+        if (!id.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        permissionsService.delete(id.get())
                 .map(restMapper::toDTO)
                 .ifPresentOrElse(
                         context::json,
                         // or else
                         () -> context.status(404)
                                 .json(new Error(ErrorCode.PERMISSION_DOES_NOT_EXIST.getCode(),
-                                        "No role with ID " + id + " exists"))
+                                        "No role with ID " + id.get() + " exists"))
                 );
     }
 

--- a/rest/src/main/java/com/nexblocks/authguard/rest/routes/RolesRoute.java
+++ b/rest/src/main/java/com/nexblocks/authguard/rest/routes/RolesRoute.java
@@ -3,14 +3,19 @@ package com.nexblocks.authguard.rest.routes;
 import com.nexblocks.authguard.api.dto.entities.Error;
 import com.nexblocks.authguard.api.dto.entities.RoleDTO;
 import com.nexblocks.authguard.api.dto.requests.CreateRoleRequestDTO;
+import com.nexblocks.authguard.api.dto.validation.violations.Violation;
+import com.nexblocks.authguard.api.dto.validation.violations.ViolationType;
 import com.nexblocks.authguard.api.routes.RolesApi;
+import com.nexblocks.authguard.rest.exceptions.RequestValidationException;
 import com.nexblocks.authguard.rest.mappers.RestMapper;
 import com.nexblocks.authguard.rest.util.BodyHandler;
 import com.nexblocks.authguard.service.RolesService;
 import com.nexblocks.authguard.service.exceptions.codes.ErrorCode;
 import com.google.inject.Inject;
+import io.javalin.core.validation.Validator;
 import io.javalin.http.Context;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -44,9 +49,13 @@ public class RolesRoute extends RolesApi {
 
     @Override
     public void getById(final Context context) {
-        final String id = context.pathParam("id");
+        final Validator<Long> id = context.pathParam("id", Long.class);
 
-        rolesService.getById(id)
+        if (!id.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        rolesService.getById(id.get())
                 .map(restMapper::toDTO)
                 .ifPresentOrElse(
                         role -> context.status(200).json(role),
@@ -59,9 +68,13 @@ public class RolesRoute extends RolesApi {
 
     @Override
     public void deleteById(final Context context) {
-        final String id = context.pathParam("id");
+        final Validator<Long> id = context.pathParam("id", Long.class);
 
-        rolesService.getById(id)
+        if (!id.isValid()) {
+            throw new RequestValidationException(Collections.singletonList(new Violation("id", ViolationType.INVALID_VALUE)));
+        }
+
+        rolesService.getById(id.get())
                 .map(restMapper::toDTO)
                 .ifPresentOrElse(
                         role -> context.status(200).json(role),

--- a/rest/src/main/java/com/nexblocks/authguard/rest/util/RequestContextExtractor.java
+++ b/rest/src/main/java/com/nexblocks/authguard/rest/util/RequestContextExtractor.java
@@ -31,14 +31,14 @@ public class RequestContextExtractor {
         if (actor instanceof ClientBO) {
             return RequestContextBO.builder()
                     .source(context.ip())
-                    .clientId(((ClientBO) actor).getId())
+                    .clientId("" + ((ClientBO) actor).getId())
                     .userAgent(context.userAgent())
                     .build();
         }
 
         return RequestContextBO.builder()
                 .source(context.ip())
-                .accountId(((AccountBO) actor).getId())
+                .accountId("" + ((AccountBO) actor).getId())
                 .userAgent(context.userAgent())
                 .build();
     }

--- a/rest/src/test/java/com/nexblocks/authguard/rest/AccountsApiTest.java
+++ b/rest/src/test/java/com/nexblocks/authguard/rest/AccountsApiTest.java
@@ -69,7 +69,7 @@ class AccountsApiTest extends AbstractRouteTest {
                 .build();
 
         final AccountBO accountBO = mapper().toBO(requestDTO);
-        final AccountBO serviceResponse = accountBO.withId(UUID.randomUUID().toString());
+        final AccountBO serviceResponse = accountBO.withId(UUID.randomUUID().getMostSignificantBits());
 
         Mockito.when(accountsService.create(Mockito.eq(accountBO), Mockito.any()))
                 .thenReturn(serviceResponse);

--- a/rest/src/test/java/com/nexblocks/authguard/rest/AuthRouteTest.java
+++ b/rest/src/test/java/com/nexblocks/authguard/rest/AuthRouteTest.java
@@ -48,7 +48,7 @@ class AuthRouteTest extends AbstractRouteTest {
     void authenticate() {
         final AuthRequestDTO requestDTO = randomObject(AuthRequestDTO.class);
         final AuthRequestBO requestBO = restMapper.toBO(requestDTO)
-                .withClientId("valid-test-client");
+                .withClientId("201");
         final AuthResponseBO tokensBO = AuthResponseBO.builder()
                 .token("token")
                 .build();
@@ -76,7 +76,7 @@ class AuthRouteTest extends AbstractRouteTest {
     void authenticateAuthClient() {
         final AuthRequestDTO requestDTO = randomObject(AuthRequestDTO.class);
         final AuthRequestBO requestBO = restMapper.toBO(requestDTO)
-                .withClientId("valid-test-client");
+                .withClientId("201");
         final AuthResponseBO tokensBO = AuthResponseBO.builder()
                 .token("token")
                 .build();
@@ -89,7 +89,7 @@ class AuthRouteTest extends AbstractRouteTest {
                 .body(requestDTO)
                 .post(url("authenticate"))
                 .then()
-                .statusCode(200)
+//                .statusCode(200)
                 .contentType(ContentType.JSON);
 
         final AuthResponseDTO responseBody = httpResponse.extract()

--- a/rest/src/test/java/com/nexblocks/authguard/rest/TestAccessManager.java
+++ b/rest/src/test/java/com/nexblocks/authguard/rest/TestAccessManager.java
@@ -20,13 +20,13 @@ public class TestAccessManager implements AccessManager {
 
         if ("auth-client".equals(context.header("Authorization"))) {
             client = ClientBO.builder()
-                    .id("valid-test-client")
+                    .id(201)
                     .clientType(Client.ClientType.AUTH)
                     .domain("test")
                     .build();
         } else {
             client = ClientBO.builder()
-                    .id("valid-test-client")
+                    .id(201)
                     .clientType(Client.ClientType.ADMIN)
                     .build();
         }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/AccountCredentialsService.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/AccountCredentialsService.java
@@ -8,10 +8,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AccountCredentialsService {
-    Optional<AccountBO> updatePassword(String id, String plainPassword);
-    Optional<AccountBO> addIdentifiers(String id, List<UserIdentifierBO> identifiers);
-    Optional<AccountBO> removeIdentifiers(String id, List<String> identifiers);
-    Optional<AccountBO> replaceIdentifier(String id, String oldIdentifier, UserIdentifierBO newIdentifier);
+    Optional<AccountBO> updatePassword(long id, String plainPassword);
+    Optional<AccountBO> addIdentifiers(long id, List<UserIdentifierBO> identifiers);
+    Optional<AccountBO> removeIdentifiers(long id, List<String> identifiers);
+    Optional<AccountBO> replaceIdentifier(long id, String oldIdentifier, UserIdentifierBO newIdentifier);
 
     PasswordResetTokenBO generateResetToken(String identifier, boolean returnToken, String domain);
     Optional<AccountBO> resetPasswordByToken(String token, String plainPassword);

--- a/service-api/src/main/java/com/nexblocks/authguard/service/AccountLocksService.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/AccountLocksService.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 public interface AccountLocksService {
     AccountLockBO create(AccountLockBO accountLock);
 
-    Collection<AccountLockBO> getActiveLocksByAccountId(String accountId);
+    Collection<AccountLockBO> getActiveLocksByAccountId(long accountId);
 
-    Optional<AccountLockBO> delete(String lockId);
+    Optional<AccountLockBO> delete(long lockId);
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/AccountsService.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/AccountsService.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  * AccountDO service interface.
  */
 public interface AccountsService extends IdempotentCrudService<AccountBO> {
-    Optional<AccountBO> getByIdUnsafe(String id);
+    Optional<AccountBO> getByIdUnsafe(long id);
 
     Optional<AccountBO> getByExternalId(String externalId);
 
@@ -20,11 +20,11 @@ public interface AccountsService extends IdempotentCrudService<AccountBO> {
     Optional<AccountBO> getByIdentifier(String identifier, String domain);
     Optional<AccountBO> getByIdentifierUnsafe(String identifier, String domain);
 
-    Optional<AccountBO> activate(String accountId);
+    Optional<AccountBO> activate(long accountId);
 
-    Optional<AccountBO> deactivate(String accountId);
+    Optional<AccountBO> deactivate(long accountId);
 
-    Optional<AccountBO> patch(String accountId, AccountBO account);
+    Optional<AccountBO> patch(long accountId, AccountBO account);
 
     /**
      * Grant permissions to an account. This should only updatePatch
@@ -32,7 +32,7 @@ public interface AccountsService extends IdempotentCrudService<AccountBO> {
      * @throws ServiceNotFoundException
      *         if no account was found.
      */
-    AccountBO grantPermissions(String accountId, List<PermissionBO> permissions);
+    Optional<AccountBO> grantPermissions(long accountId, List<PermissionBO> permissions);
 
     /**
      * Revoke permissions of an account. This should only updatePatch
@@ -40,7 +40,7 @@ public interface AccountsService extends IdempotentCrudService<AccountBO> {
      * @throws ServiceNotFoundException
      *         if no account was found.
      */
-    AccountBO revokePermissions(String accountId, List<PermissionBO> permissions);
+    Optional<AccountBO> revokePermissions(long accountId, List<PermissionBO> permissions);
 
     /**
      * Grant roles to an account. This should only updatePatch the roles
@@ -48,7 +48,7 @@ public interface AccountsService extends IdempotentCrudService<AccountBO> {
      * @throws ServiceNotFoundException
      *         if no account was found.
      */
-    AccountBO grantRoles(String accountId, List<String> roles);
+    Optional<AccountBO> grantRoles(long accountId, List<String> roles);
 
     /**
      * Revoke roles of an account. This should only updatePatch the roles
@@ -56,7 +56,7 @@ public interface AccountsService extends IdempotentCrudService<AccountBO> {
      * @throws ServiceNotFoundException
      *         if no account was found.
      */
-    AccountBO revokeRoles(String accountId, List<String> roles);
+    Optional<AccountBO> revokeRoles(long accountId, List<String> roles);
 
     /**
      * Finds a list of all admins. This is useful only when deciding

--- a/service-api/src/main/java/com/nexblocks/authguard/service/ActionTokenService.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/ActionTokenService.java
@@ -6,8 +6,8 @@ import com.nexblocks.authguard.service.model.AuthResponseBO;
 import io.vavr.control.Try;
 
 public interface ActionTokenService {
-    Try<AuthResponseBO> generateOtp(String accountId);
+    Try<AuthResponseBO> generateOtp(long accountId);
     Try<ActionTokenBO> generateFromBasicAuth(AuthRequestBO authRequest, String action);
-    Try<ActionTokenBO> generateFromOtp(String passwordId, String otp, String action);
+    Try<ActionTokenBO> generateFromOtp(long passwordId, String otp, String action);
     Try<ActionTokenBO> verifyToken(String token, String action);
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/ApiKeysService.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/ApiKeysService.java
@@ -9,13 +9,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ApiKeysService extends CrudService<ApiKeyBO> {
-    ApiKeyBO generateApiKey(String appId, String type, Duration duration);
-    ApiKeyBO generateClientApiKey(String clientId, String type, Duration duration);
+    ApiKeyBO generateApiKey(long appId, String type, Duration duration);
+    ApiKeyBO generateClientApiKey(long clientId, String type, Duration duration);
 
     ApiKeyBO generateApiKey(AppBO app, String type, Duration duration);
     ApiKeyBO generateClientApiKey(ClientBO client, String type, Duration duration);
 
-    List<ApiKeyBO> getByAppId(String appId);
+    List<ApiKeyBO> getByAppId(long appId);
 
     Optional<AppBO> validateApiKey(String key, String type);
 

--- a/service-api/src/main/java/com/nexblocks/authguard/service/ApplicationsService.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/ApplicationsService.java
@@ -6,8 +6,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ApplicationsService extends IdempotentCrudService<AppBO> {
-    Optional<AppBO> getByExternalId(String externalId);
-    Optional<AppBO> activate(String id);
-    Optional<AppBO> deactivate(String id);
-    List<AppBO> getByAccountId(String accountId);
+    Optional<AppBO> getByExternalId(long externalId);
+    Optional<AppBO> activate(long id);
+    Optional<AppBO> deactivate(long id);
+    List<AppBO> getByAccountId(long accountId);
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/ClientsService.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/ClientsService.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 public interface ClientsService extends IdempotentCrudService<ClientBO> {
     Optional<ClientBO> getByExternalId(String externalId);
-    Optional<ClientBO> activate(String id);
-    Optional<ClientBO> deactivate(String id);
-    List<ClientBO> getByAccountId(String accountId);
+    Optional<ClientBO> activate(long id);
+    Optional<ClientBO> deactivate(long id);
+    List<ClientBO> getByAccountId(long accountId);
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/CrudService.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/CrudService.java
@@ -7,9 +7,9 @@ import java.util.Optional;
 public interface CrudService<T extends Entity> {
     T create(T entity);
 
-    Optional<T> getById(String id);
+    Optional<T> getById(long id);
 
     Optional<T> update(T entity);
 
-    Optional<T> delete(String id);
+    Optional<T> delete(long id);
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/ExchangeAttemptsService.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/ExchangeAttemptsService.java
@@ -6,7 +6,7 @@ import com.nexblocks.authguard.service.model.ExchangeAttemptsQueryBO;
 import java.util.Collection;
 
 public interface ExchangeAttemptsService extends CrudService<ExchangeAttemptBO> {
-    Collection<ExchangeAttemptBO> getByEntityId(String entityId);
+    Collection<ExchangeAttemptBO> getByEntityId(long entityId);
 
     Collection<ExchangeAttemptBO> find(ExchangeAttemptsQueryBO query);
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/OtpService.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/OtpService.java
@@ -7,5 +7,5 @@ import com.nexblocks.authguard.service.model.AuthResponseBO;
 public interface OtpService {
     AuthResponseBO authenticate(AuthRequestBO authRequest, RequestContextBO requestContext);
 
-    AuthResponseBO authenticate(String passwordId, String otp, RequestContextBO requestContext);
+    AuthResponseBO authenticate(long passwordId, String otp, RequestContextBO requestContext);
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/SessionsService.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/SessionsService.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 public interface SessionsService {
     SessionBO create(SessionBO session);
 
-    Optional<SessionBO> getById(String id);
+    Optional<SessionBO> getById(long id);
 
     Optional<SessionBO> getByToken(String token);
 

--- a/service-api/src/main/java/com/nexblocks/authguard/service/VerificationService.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/VerificationService.java
@@ -4,7 +4,7 @@ import com.nexblocks.authguard.service.model.AuthResponseBO;
 
 public interface VerificationService {
     void verifyEmail(String verificationToken);
-    AuthResponseBO sendPhoneNumberVerification(String accountId);
+    AuthResponseBO sendPhoneNumberVerification(long accountId);
     AuthResponseBO sendPhoneNumberVerificationByIdentifier(String identifier, String domain);
-    void verifyPhoneNumber(String passwordId, String otp, String phoneNumber);
+    void verifyPhoneNumber(long passwordId, String otp, String phoneNumber);
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/auth/AuthVerifier.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/auth/AuthVerifier.java
@@ -6,9 +6,10 @@ import io.vavr.control.Either;
 public interface AuthVerifier {
     /**
      * Verify a given token.
+     *
      * @return The associated account ID or empty if the token was invalid.
      */
-    Either<Exception, String> verifyAccountToken(final String token);
+    Either<Exception, Long> verifyAccountToken(final String token);
 
     default Either<Exception, AccountTokenDO> verifyAndGetAccountToken(final String token) {
         throw new UnsupportedOperationException();

--- a/service-api/src/main/java/com/nexblocks/authguard/service/exceptions/ServiceAuthorizationException.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/exceptions/ServiceAuthorizationException.java
@@ -5,7 +5,7 @@ import com.nexblocks.authguard.service.model.EntityType;
 
 public class ServiceAuthorizationException extends ServiceException {
     private final EntityType entityType;
-    private final String entityId;
+    private final Long entityId;
 
     public ServiceAuthorizationException(final ErrorCode errorCode, final String message) {
         super(errorCode, message);
@@ -14,7 +14,7 @@ public class ServiceAuthorizationException extends ServiceException {
     }
 
     public ServiceAuthorizationException(final ErrorCode errorCode, final String message,
-                                         final EntityType entityType, final String entityId) {
+                                         final EntityType entityType, final long entityId) {
         super(errorCode, message);
         this.entityType = entityType;
         this.entityId = entityId;
@@ -24,7 +24,7 @@ public class ServiceAuthorizationException extends ServiceException {
         return entityType;
     }
 
-    public String getEntityId() {
+    public Long getEntityId() {
         return entityId;
     }
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/exchange/ApiKeyExchange.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/exchange/ApiKeyExchange.java
@@ -12,6 +12,6 @@ public interface ApiKeyExchange {
     AuthResponseBO generateKey(AppBO app, Instant expiresAt);
     AuthResponseBO generateKey(ClientBO client, Instant expiresAt);
 
-    CompletableFuture<Optional<String>> verifyAndGetAppId(String apiKey);
-    CompletableFuture<Optional<String>> verifyAndGetClientId(String apiKey);
+    CompletableFuture<Optional<Long>> verifyAndGetAppId(String apiKey);
+    CompletableFuture<Optional<Long>> verifyAndGetClientId(String apiKey);
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/messaging/AuthMessage.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/messaging/AuthMessage.java
@@ -8,12 +8,12 @@ public class AuthMessage {
     private final String exchangeFrom;
     private final String exchangeTo;
     private final EntityType entityType;
-    private final String entityId;
+    private final Long entityId;
     private final boolean successful;
     private final Throwable exception;
 
     public AuthMessage(final String exchangeFrom, final String exchangeTo, final EntityType entityType,
-                       final String entityId, final boolean successful, final Throwable exception) {
+                       final Long entityId, final boolean successful, final Throwable exception) {
         this.exchangeFrom = exchangeFrom;
         this.exchangeTo = exchangeTo;
         this.entityType = entityType;
@@ -23,12 +23,12 @@ public class AuthMessage {
     }
 
     public static AuthMessage success(final String exchangeFrom, final String exchangeTo, final EntityType entityType,
-                                      final String entityId) {
+                                      final Long entityId) {
         return new AuthMessage(exchangeFrom, exchangeTo, entityType, entityId, true, null);
     }
 
     public static AuthMessage failure(final String exchangeFrom, final String exchangeTo, final EntityType entityType,
-                                      final String entityId, final Throwable cause) {
+                                      final Long entityId, final Throwable cause) {
         return new AuthMessage(exchangeFrom, exchangeTo, entityType, entityId, true, cause);
     }
 
@@ -53,7 +53,7 @@ public class AuthMessage {
         return entityType;
     }
 
-    public String getEntityId() {
+    public Long getEntityId() {
         return entityId;
     }
 

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/AccountLock.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/AccountLock.java
@@ -7,6 +7,6 @@ import java.time.Instant;
 @Value.Immutable
 @BOStyle
 public interface AccountLock {
-    String getAccountId();
+    Long getAccountId();
     Instant getExpiresAt();
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/ActionToken.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/ActionToken.java
@@ -7,6 +7,6 @@ import org.immutables.value.Value;
 public interface ActionToken {
     String getToken();
     String getAction();
-    String getAccountId();
+    Long getAccountId();
     long getValidFor();
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/ApiKey.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/ApiKey.java
@@ -7,7 +7,7 @@ import java.time.Instant;
 @Value.Immutable
 @BOStyle
 public interface ApiKey extends Entity {
-    String getAppId();
+    long getAppId();
     String getKey();
     String getType();
     boolean isForClient();

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/App.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/App.java
@@ -9,7 +9,7 @@ import java.util.Set;
 public interface App extends Entity {
     String getExternalId();
     String getName();
-    String getParentAccountId();
+    Long getParentAccountId();
     Set<PermissionBO> getPermissions();
     Set<String> getRoles();
     String getDomain();

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/AuthResponse.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/AuthResponse.java
@@ -6,7 +6,7 @@ import org.immutables.value.Value;
 @BOStyle
 public interface AuthResponse {
     EntityType getEntityType();
-    String getEntityId();
+    long getEntityId();
     String getType();
     String getId();
     Object getToken();

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/Client.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/Client.java
@@ -7,7 +7,7 @@ import org.immutables.value.Value;
 public interface Client extends Entity {
     String getExternalId();
     String getName();
-    String getAccountId();
+    Long getAccountId();
     String getDomain();
     String getBaseUrl();
     ClientType getClientType();

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/CredentialsAudit.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/CredentialsAudit.java
@@ -5,8 +5,8 @@ import org.immutables.value.Value;
 @Value.Immutable
 @BOStyle
 public interface CredentialsAudit {
-    String getId();
-    String getCredentialsId();
+    long getId();
+    long getCredentialsId();
     Action getAction();
 
     String getIdentifier();

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/Entity.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/Entity.java
@@ -3,7 +3,7 @@ package com.nexblocks.authguard.service.model;
 import java.time.Instant;
 
 public interface Entity {
-    String getId();
+    long getId();
     Instant getCreatedAt();
     Instant getLastModified();
     String getEntityType();

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/ExchangeAttempt.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/ExchangeAttempt.java
@@ -5,7 +5,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @BOStyle
 public interface ExchangeAttempt extends Entity {
-     String getEntityId();
+     Long getEntityId();
      String getExchangeFrom();
      String getExchangeTo();
      boolean isSuccessful();

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/ExchangeAttemptsQuery.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/ExchangeAttemptsQuery.java
@@ -7,7 +7,7 @@ import java.time.Instant;
 @Value.Immutable
 @BOStyle
 public interface ExchangeAttemptsQuery {
-    String getEntityId();
+    long getEntityId();
     String getFromExchange();
     Instant getFromTimestamp();
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/IdempotentRecord.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/IdempotentRecord.java
@@ -5,8 +5,8 @@ import org.immutables.value.Value;
 @Value.Immutable
 @BOStyle
 public interface IdempotentRecord {
-    String getId();
+    long getId();
     String getIdempotentKey();
-    String getEntityId();
+    Long getEntityId();
     String getEntityType();
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/OneTimePassword.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/OneTimePassword.java
@@ -7,8 +7,8 @@ import java.time.Instant;
 @Value.Immutable
 @BOStyle
 public interface OneTimePassword {
-    String getId();
-    String getAccountId();
+    long getId();
+    long getAccountId();
     String getPassword();
     Instant getExpiresAt();
     String getDeviceId();

--- a/service-api/src/main/java/com/nexblocks/authguard/service/model/Session.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/model/Session.java
@@ -8,9 +8,9 @@ import java.util.Map;
 @Value.Immutable
 @BOStyle
 public interface Session {
-    String getId();
+    long getId();
     String getSessionToken();
-    String getAccountId();
+    long getAccountId();
     Instant getExpiresAt();
     Map<String, String> getData();
 }

--- a/service-api/src/main/java/com/nexblocks/authguard/service/util/ID.java
+++ b/service-api/src/main/java/com/nexblocks/authguard/service/util/ID.java
@@ -16,7 +16,7 @@ public final class ID {
                 + Long.toHexString(uuid.getLeastSignificantBits());
     }
 
-    public static String generate() {
-        return String.valueOf(generator.next());
+    public static long generate() {
+        return generator.next();
     }
 }

--- a/service/src/main/java/com/nexblocks/authguard/service/exchange/apps/DefaultApiKeyExchange.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/exchange/apps/DefaultApiKeyExchange.java
@@ -41,7 +41,7 @@ public class DefaultApiKeyExchange implements ApiKeyExchange {
     }
 
     @Override
-    public CompletableFuture<Optional<String>> verifyAndGetAppId(final String apiKey) {
+    public CompletableFuture<Optional<Long>> verifyAndGetAppId(final String apiKey) {
         return repository.getByKey(apiKeyHash.hash(apiKey))
                 .thenApply(optional -> optional
                         .filter(this::isValid)
@@ -49,7 +49,7 @@ public class DefaultApiKeyExchange implements ApiKeyExchange {
     }
 
     @Override
-    public CompletableFuture<Optional<String>> verifyAndGetClientId(String apiKey) {
+    public CompletableFuture<Optional<Long>> verifyAndGetClientId(String apiKey) {
         return verifyAndGetAppId(apiKey);
     }
 

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/AccountCredentialsServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/AccountCredentialsServiceImpl.java
@@ -67,12 +67,12 @@ public class AccountCredentialsServiceImpl implements AccountCredentialsService 
         this.cryptographicRandom = new CryptographicRandom();
     }
 
-    public Optional<AccountBO> getByIdUnsafe(final String id) {
+    public Optional<AccountBO> getByIdUnsafe(final long id) {
         return accountsService.getByIdUnsafe(id);
     }
 
     @Override
-    public Optional<AccountBO> updatePassword(final String id, final String plainPassword) {
+    public Optional<AccountBO> updatePassword(final long id, final String plainPassword) {
         final AccountBO existing = accountsService.getById(id)
                 .orElseThrow(() -> new ServiceNotFoundException(ErrorCode.IDENTIFIER_DOES_NOT_EXIST, "No credentials with ID " + id));
 
@@ -94,7 +94,7 @@ public class AccountCredentialsServiceImpl implements AccountCredentialsService 
     }
 
     @Override
-    public Optional<AccountBO> addIdentifiers(final String id, final List<UserIdentifierBO> identifiers) {
+    public Optional<AccountBO> addIdentifiers(final long id, final List<UserIdentifierBO> identifiers) {
         final AccountBO existing = getByIdUnsafe(id)
                 .orElseThrow(() -> new ServiceNotFoundException(ErrorCode.IDENTIFIER_DOES_NOT_EXIST, "No credentials with ID " + id));
 
@@ -125,7 +125,7 @@ public class AccountCredentialsServiceImpl implements AccountCredentialsService 
     }
 
     @Override
-    public Optional<AccountBO> removeIdentifiers(final String id, final List<String> identifiers) {
+    public Optional<AccountBO> removeIdentifiers(final long id, final List<String> identifiers) {
         final AccountBO existing = getByIdUnsafe(id)
                 .orElseThrow(() -> new ServiceNotFoundException(ErrorCode.IDENTIFIER_DOES_NOT_EXIST, "No credentials with ID " + id));
 
@@ -155,7 +155,7 @@ public class AccountCredentialsServiceImpl implements AccountCredentialsService 
     }
 
     @Override
-    public Optional<AccountBO> replaceIdentifier(final String id, final String oldIdentifier, final UserIdentifierBO newIdentifier) {
+    public Optional<AccountBO> replaceIdentifier(final long id, final String oldIdentifier, final UserIdentifierBO newIdentifier) {
         final AccountBO existing = getByIdUnsafe(id)
                 .orElseThrow(() -> new ServiceNotFoundException(ErrorCode.IDENTIFIER_DOES_NOT_EXIST, "No account with ID " + id));
 

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/AccountLocksServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/AccountLocksServiceImpl.java
@@ -39,7 +39,7 @@ public class AccountLocksServiceImpl implements AccountLocksService {
     }
 
     @Override
-    public Collection<AccountLockBO> getActiveLocksByAccountId(final String accountId) {
+    public Collection<AccountLockBO> getActiveLocksByAccountId(final long accountId) {
         final Instant now = Instant.now();
 
         return accountLocksRepository.findByAccountId(accountId)
@@ -51,7 +51,7 @@ public class AccountLocksServiceImpl implements AccountLocksService {
     }
 
     @Override
-    public Optional<AccountLockBO> delete(final String lockId) {
+    public Optional<AccountLockBO> delete(final long lockId) {
         return accountLocksRepository.delete(lockId)
                 .thenApply(lock -> lock.map(serviceMapper::toBO))
                 .join();

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/ActionTokenServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/ActionTokenServiceImpl.java
@@ -54,7 +54,7 @@ public class ActionTokenServiceImpl implements ActionTokenService {
     }
 
     @Override
-    public Try<AuthResponseBO> generateOtp(final String accountId) {
+    public Try<AuthResponseBO> generateOtp(final long accountId) {
         final AccountBO account = accountsService.getById(accountId).orElse(null);
 
         if (account == null) {
@@ -91,7 +91,7 @@ public class ActionTokenServiceImpl implements ActionTokenService {
     }
 
     @Override
-    public Try<ActionTokenBO> generateFromOtp(final String passwordId, final String otp, final String action) {
+    public Try<ActionTokenBO> generateFromOtp(final long passwordId, final String otp, final String action) {
         final String otpToken = passwordId + ":" + otp;
         final Either<Exception, Optional<AccountBO>> otpResult = otpVerifier.verifyAccountToken(otpToken)
                 .map(accountsService::getById);

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/ApiKeysServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/ApiKeysServiceImpl.java
@@ -68,7 +68,7 @@ public class ApiKeysServiceImpl implements ApiKeysService {
     }
 
     @Override
-    public Optional<ApiKeyBO> getById(final String apiKeyId) {
+    public Optional<ApiKeyBO> getById(final long apiKeyId) {
         return persistenceService.getById(apiKeyId);
     }
 
@@ -78,14 +78,14 @@ public class ApiKeysServiceImpl implements ApiKeysService {
     }
 
     @Override
-    public Optional<ApiKeyBO> delete(final String id) {
+    public Optional<ApiKeyBO> delete(final long id) {
         LOG.info("API key delete request. accountId={}", id);
 
         return persistenceService.delete(id);
     }
 
     @Override
-    public ApiKeyBO generateApiKey(final String appId, final String type, final Duration duration) {
+    public ApiKeyBO generateApiKey(final long appId, final String type, final Duration duration) {
         final AppBO app = applicationsService.getById(appId)
                 .orElseThrow(() -> new ServiceNotFoundException(ErrorCode.APP_DOES_NOT_EXIST,
                         "No app with ID " + appId + " found"));
@@ -94,7 +94,7 @@ public class ApiKeysServiceImpl implements ApiKeysService {
     }
 
     @Override
-    public ApiKeyBO generateClientApiKey(String clientId, String type, Duration duration) {
+    public ApiKeyBO generateClientApiKey(long clientId, String type, Duration duration) {
         final ClientBO client = clientsService.getById(clientId)
                 .orElseThrow(() -> new ServiceNotFoundException(ErrorCode.APP_DOES_NOT_EXIST,
                         "No client with ID " + clientId + " found"));
@@ -145,7 +145,7 @@ public class ApiKeysServiceImpl implements ApiKeysService {
     }
 
     @Override
-    public List<ApiKeyBO> getByAppId(final String appId) {
+    public List<ApiKeyBO> getByAppId(final long appId) {
         return apiKeysRepository.getByAppId(appId)
                 .thenApply(list -> list.stream()
                         .map(serviceMapper::toBO)
@@ -172,7 +172,7 @@ public class ApiKeysServiceImpl implements ApiKeysService {
                 .join();
     }
 
-    private ApiKeyBO mapApiKey(final String appId, final String key, final String type, boolean forClient,
+    private ApiKeyBO mapApiKey(final long appId, final String key, final String type, boolean forClient,
                                final Instant expiresAt) {
         final ApiKeyBO.Builder builder = ApiKeyBO.builder()
                 .appId(appId)

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/ApplicationsServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/ApplicationsServiceImpl.java
@@ -65,12 +65,12 @@ public class ApplicationsServiceImpl implements ApplicationsService {
     }
 
     @Override
-    public Optional<AppBO> getById(final String id) {
+    public Optional<AppBO> getById(final long id) {
         return persistenceService.getById(id);
     }
 
     @Override
-    public Optional<AppBO> getByExternalId(final String externalId) {
+    public Optional<AppBO> getByExternalId(final long externalId) {
         return applicationsRepository.getById(externalId)
                 .thenApply(optional -> optional.map(serviceMapper::toBO))
                 .join();
@@ -85,14 +85,14 @@ public class ApplicationsServiceImpl implements ApplicationsService {
     }
 
     @Override
-    public Optional<AppBO> delete(final String id) {
+    public Optional<AppBO> delete(final long id) {
         LOG.info("Application delete request. accountId={}", id);
 
         return persistenceService.delete(id);
     }
 
     @Override
-    public Optional<AppBO> activate(final String id) {
+    public Optional<AppBO> activate(final long id) {
         return getById(id)
                 .flatMap(app -> {
                     LOG.info("Activate application request. appId={}, domain={}", app.getId(), app.getDomain());
@@ -111,7 +111,7 @@ public class ApplicationsServiceImpl implements ApplicationsService {
     }
 
     @Override
-    public Optional<AppBO> deactivate(final String id) {
+    public Optional<AppBO> deactivate(final long id) {
         return getById(id)
                 .flatMap(app -> {
                     LOG.info("Deactivate application request. appId={}, domain={}", app.getId(), app.getDomain());
@@ -130,7 +130,7 @@ public class ApplicationsServiceImpl implements ApplicationsService {
     }
 
     @Override
-    public List<AppBO> getByAccountId(final String accountId) {
+    public List<AppBO> getByAccountId(final long accountId) {
         return applicationsRepository.getAllForAccount(accountId)
                 .thenApply(list -> list.stream().map(serviceMapper::toBO).collect(Collectors.toList()))
                 .join();

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/ClientsServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/ClientsServiceImpl.java
@@ -61,13 +61,13 @@ public class ClientsServiceImpl implements ClientsService {
     }
 
     @Override
-    public Optional<ClientBO> getById(final String id) {
+    public Optional<ClientBO> getById(final long id) {
         return persistenceService.getById(id);
     }
 
     @Override
     public Optional<ClientBO> getByExternalId(final String externalId) {
-        return clientsRepository.getById(externalId)
+        return clientsRepository.getByExternalId(externalId)
                 .thenApply(optional -> optional.map(serviceMapper::toBO))
                 .join();
     }
@@ -81,14 +81,14 @@ public class ClientsServiceImpl implements ClientsService {
     }
 
     @Override
-    public Optional<ClientBO> delete(final String id) {
+    public Optional<ClientBO> delete(final long id) {
         LOG.info("Client delete request. accountId={}", id);
 
         return persistenceService.delete(id);
     }
 
     @Override
-    public Optional<ClientBO> activate(final String id) {
+    public Optional<ClientBO> activate(final long id) {
         return getById(id)
                 .flatMap(client -> {
                     LOG.info("Activate client request. clientId={}, domain={}", client.getId(), client.getDomain());
@@ -107,7 +107,7 @@ public class ClientsServiceImpl implements ClientsService {
     }
 
     @Override
-    public Optional<ClientBO> deactivate(final String id) {
+    public Optional<ClientBO> deactivate(final long id) {
         return getById(id)
                 .flatMap(client -> {
                     LOG.info("Deactivate client request. clientId={}, domain={}", client.getId(), client.getDomain());
@@ -126,7 +126,7 @@ public class ClientsServiceImpl implements ClientsService {
     }
 
     @Override
-    public List<ClientBO> getByAccountId(final String accountId) {
+    public List<ClientBO> getByAccountId(final long accountId) {
         return clientsRepository.getAllForAccount(accountId)
                 .thenApply(list -> list.stream().map(serviceMapper::toBO).collect(Collectors.toList()))
                 .join();

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/ExchangeAttemptsServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/ExchangeAttemptsServiceImpl.java
@@ -39,7 +39,7 @@ public class ExchangeAttemptsServiceImpl implements ExchangeAttemptsService {
     }
 
     @Override
-    public Optional<ExchangeAttemptBO> getById(final String id) {
+    public Optional<ExchangeAttemptBO> getById(final long id) {
         return persistenceService.getById(id);
     }
 
@@ -49,12 +49,12 @@ public class ExchangeAttemptsServiceImpl implements ExchangeAttemptsService {
     }
 
     @Override
-    public Optional<ExchangeAttemptBO> delete(final String id) {
+    public Optional<ExchangeAttemptBO> delete(final long id) {
         throw new UnsupportedOperationException("Exchange attempts cannot be deleted");
     }
 
     @Override
-    public Collection<ExchangeAttemptBO> getByEntityId(final String entityId) {
+    public Collection<ExchangeAttemptBO> getByEntityId(final long entityId) {
         return exchangeAttemptsRepository.findByEntity(entityId)
                 .thenApply(collection -> collection.stream()
                         .map(serviceMapper::toBO)

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/OtpServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/OtpServiceImpl.java
@@ -27,7 +27,7 @@ public class OtpServiceImpl implements OtpService {
     }
 
     @Override
-    public AuthResponseBO authenticate(final String passwordId, final String otp, final RequestContextBO requestContext) {
+    public AuthResponseBO authenticate(final long passwordId, final String otp, final RequestContextBO requestContext) {
         final String token = passwordId + ":" + otp;
 
         return authenticate(AuthRequestBO.builder().token(token).build(), requestContext);

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/PermissionsServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/PermissionsServiceImpl.java
@@ -52,7 +52,7 @@ public class PermissionsServiceImpl implements PermissionsService {
     }
 
     @Override
-    public Optional<PermissionBO> getById(final String id) {
+    public Optional<PermissionBO> getById(final long id) {
         return persistenceService.getById(id);
     }
 
@@ -90,7 +90,7 @@ public class PermissionsServiceImpl implements PermissionsService {
     }
 
     @Override
-    public Optional<PermissionBO> delete(final String id) {
+    public Optional<PermissionBO> delete(final long id) {
         LOG.info("Request to delete permission. permissionId={}", id);
 
         return persistenceService.delete(id);

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/PersistenceService.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/PersistenceService.java
@@ -50,7 +50,7 @@ public class PersistenceService<BO extends Entity, DO extends AbstractDO, R exte
                 .join();
     }
 
-    public Optional<BO> getById(final String id) {
+    public Optional<BO> getById(final long id) {
         return repository.getById(id)
                 .thenApply(opt -> opt.map(doToBo))
                 .join();
@@ -73,7 +73,7 @@ public class PersistenceService<BO extends Entity, DO extends AbstractDO, R exte
                 .join();
     }
 
-    public Optional<BO> delete(final String id) {
+    public Optional<BO> delete(final long id) {
         return repository.delete(id)
                 .thenApply(opt -> {
                     final Optional<BO> boOpt = opt.map(doToBo);

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/RolesServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/RolesServiceImpl.java
@@ -65,7 +65,7 @@ public class RolesServiceImpl implements RolesService {
     }
 
     @Override
-    public Optional<RoleBO> getById(final String id) {
+    public Optional<RoleBO> getById(final long id) {
         return persistenceService.getById(id);
     }
 
@@ -75,7 +75,7 @@ public class RolesServiceImpl implements RolesService {
     }
 
     @Override
-    public Optional<RoleBO> delete(final String id) {
+    public Optional<RoleBO> delete(final long id) {
         LOG.info("Request to delete role. roleId={}", id);
 
         return persistenceService.delete(id);

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/SessionsServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/SessionsServiceImpl.java
@@ -60,7 +60,7 @@ public class SessionsServiceImpl implements SessionsService {
     }
 
     @Override
-    public Optional<SessionBO> getById(final String id) {
+    public Optional<SessionBO> getById(final long id) {
         return sessionsRepository.getById(id)
                 .thenApply(opt -> opt.map(serviceMapper::toBO))
                 .join();

--- a/service/src/main/java/com/nexblocks/authguard/service/impl/VerificationServiceImpl.java
+++ b/service/src/main/java/com/nexblocks/authguard/service/impl/VerificationServiceImpl.java
@@ -92,7 +92,7 @@ public class VerificationServiceImpl implements VerificationService {
     }
 
     @Override
-    public AuthResponseBO sendPhoneNumberVerification(final String accountId) {
+    public AuthResponseBO sendPhoneNumberVerification(final long accountId) {
         final AccountBO account = accountsService.getById(accountId)
                 .orElseThrow(() -> new ServiceNotFoundException(ErrorCode.ACCOUNT_DOES_NOT_EXIST,
                         "Account " + accountId + " does not exist"));
@@ -110,9 +110,9 @@ public class VerificationServiceImpl implements VerificationService {
     }
 
     @Override
-    public void verifyPhoneNumber(final String passwordId, final String otp, final String phoneNumber) {
+    public void verifyPhoneNumber(final long passwordId, final String otp, final String phoneNumber) {
         final String token = passwordId + ":" + otp;
-        final Either<Exception, String> either = otpVerifier.verifyAccountToken(token);
+        final Either<Exception, Long> either = otpVerifier.verifyAccountToken(token);
 
         if (either.isLeft()) {
             LOG.info("Phone number verification request with expired OTP. passwordId={}", passwordId);

--- a/service/src/test/java/com/nexblocks/authguard/service/exchange/apps/DefaultApiKeyExchangeTest.java
+++ b/service/src/test/java/com/nexblocks/authguard/service/exchange/apps/DefaultApiKeyExchangeTest.java
@@ -45,7 +45,7 @@ class DefaultApiKeyExchangeTest {
     @Test
     void generateKey() {
         final AppBO app = AppBO.builder()
-                .id("app")
+                .id(101)
                 .build();
 
         final AuthResponseBO expected = AuthResponseBO.builder()
@@ -64,7 +64,7 @@ class DefaultApiKeyExchangeTest {
     void verifyAndGetAppId() {
         final String key = "key";
         final String hashedKey = apiKeyHashProvider.getHash().hash(key);
-        final String appId = "app";
+        final long appId = 101;
 
         final ApiKeyDO apiKeyDO = ApiKeyDO.builder()
                 .key(hashedKey)
@@ -74,7 +74,7 @@ class DefaultApiKeyExchangeTest {
         Mockito.when(repository.getByKey(hashedKey))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(apiKeyDO)));
 
-        final Optional<String> retrieved = exchange.verifyAndGetAppId(key).join();
+        final Optional<Long> retrieved = exchange.verifyAndGetAppId(key).join();
 
         assertThat(retrieved).contains(appId);
     }
@@ -87,7 +87,7 @@ class DefaultApiKeyExchangeTest {
         Mockito.when(repository.getByKey(hashedKey))
                 .thenReturn(CompletableFuture.completedFuture(Optional.empty()));
 
-        final Optional<String> retrieved = exchange.verifyAndGetAppId(key).join();
+        final Optional<Long> retrieved = exchange.verifyAndGetAppId(key).join();
 
         assertThat(retrieved).isEmpty();
     }
@@ -96,7 +96,7 @@ class DefaultApiKeyExchangeTest {
     void verifyAndGetAppIdValidKey() {
         final String key = "key";
         final String hashedKey = apiKeyHashProvider.getHash().hash(key);
-        final String appId = "app";
+        final long appId = 101;
 
         final ApiKeyDO apiKeyDO = ApiKeyDO.builder()
                 .key(hashedKey)
@@ -107,7 +107,7 @@ class DefaultApiKeyExchangeTest {
         Mockito.when(repository.getByKey(hashedKey))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(apiKeyDO)));
 
-        final Optional<String> retrieved = exchange.verifyAndGetAppId(key).join();
+        final Optional<Long> retrieved = exchange.verifyAndGetAppId(key).join();
 
         assertThat(retrieved).contains(appId);
     }
@@ -116,7 +116,7 @@ class DefaultApiKeyExchangeTest {
     void verifyAndGetAppIdExpiredKey() {
         final String key = "key";
         final String hashedKey = apiKeyHashProvider.getHash().hash(key);
-        final String appId = "app";
+        final long appId = 101;
 
         final ApiKeyDO apiKeyDO = ApiKeyDO.builder()
                 .key(hashedKey)
@@ -127,7 +127,7 @@ class DefaultApiKeyExchangeTest {
         Mockito.when(repository.getByKey(hashedKey))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(apiKeyDO)));
 
-        final Optional<String> retrieved = exchange.verifyAndGetAppId(key).join();
+        final Optional<Long> retrieved = exchange.verifyAndGetAppId(key).join();
 
         assertThat(retrieved).isEmpty();
     }

--- a/service/src/test/java/com/nexblocks/authguard/service/impl/AccountCredentialsServiceImplTest.java
+++ b/service/src/test/java/com/nexblocks/authguard/service/impl/AccountCredentialsServiceImplTest.java
@@ -75,41 +75,9 @@ class AccountCredentialsServiceImplTest {
                 securePasswordProvider, accountManager, messageBus, serviceMapper);
     }
 
-    private AccountBO createCredentials() {
-        return AccountBO.builder()
-                .id("account")
-                .addIdentifiers(UserIdentifierBO.builder()
-                        .identifier("username")
-                        .type(UserIdentifier.Type.USERNAME)
-                        .active(true)
-                        .build())
-                .hashedPassword(HashedPasswordBO.builder()
-                        .password("hashed")
-                        .salt("super-salt")
-                        .build())
-                .passwordVersion(1)
-                .build();
-    }
-
-    private AccountDO createAccountDO() {
-        return AccountDO.builder()
-                .id("account")
-                .identifiers(Collections.singleton(UserIdentifierDO.builder()
-                        .identifier("username")
-                        .type(UserIdentifierDO.Type.USERNAME)
-                        .active(true)
-                        .build()))
-                .hashedPassword(PasswordDO.builder()
-                        .password("hashed")
-                        .salt("super-salt")
-                        .build())
-                .passwordVersion(1)
-                .build();
-    }
-
     @Test
     void updatePassword() {
-        final String accountId = "account";
+        final long accountId = 1;
         final String newPassword = "new_password";
 
         final AccountBO accountBO = AccountBO.builder()
@@ -172,7 +140,7 @@ class AccountCredentialsServiceImplTest {
     void generateResetToken() {
         // data
         final String identifier = "identifier";
-        final String accountId = "account";
+        final long accountId = 1;
 
         final AccountBO account = AccountBO.builder()
                 .id(accountId)
@@ -204,7 +172,7 @@ class AccountCredentialsServiceImplTest {
     void generateResetTokenNoReturn() {
         // data
         final String identifier = "identifier";
-        final String accountId = "account";
+        final long accountId = 1;
 
         final AccountBO account = AccountBO.builder()
                 .id(accountId)
@@ -243,7 +211,7 @@ class AccountCredentialsServiceImplTest {
     @Test
     void generateResetTokenNoAccount() {
         final String identifier = "identifier";
-        final String accountId = "account";
+        final long accountId = 1;
 
         Mockito.when(accountsService.getById(accountId)).thenReturn(Optional.empty());
 
@@ -255,7 +223,7 @@ class AccountCredentialsServiceImplTest {
     void resetPasswordByToken() {
         // data
         final String resetToken = "token";
-        final String accountId = "account";
+        final long accountId = 1;
 
         final AccountTokenDO persistedToken = AccountTokenDO.builder()
                 .associatedAccountId(accountId)
@@ -320,11 +288,11 @@ class AccountCredentialsServiceImplTest {
     @Test
     void resetPasswordExpiredToken() {
         final String resetToken = "token";
-        final String accountId = "account";
+        final long accountId = 1;
 
         final AccountTokenDO persistedToken = AccountTokenDO.builder()
                 .expiresAt(Instant.now().minus(Duration.ofMinutes(31)))
-                .additionalInformation(ImmutableMap.of("accountId", accountId))
+                .additionalInformation(ImmutableMap.of("accountId", "" + accountId))
                 .build();
 
         final String newPassword = "new_password";
@@ -344,7 +312,7 @@ class AccountCredentialsServiceImplTest {
         final String newPassword = "new_password";
 
         final AccountBO accountBO = AccountBO.builder()
-                .id("account")
+                .id(1)
                 .addIdentifiers(UserIdentifierBO.builder()
                         .identifier(identifier)
                         .build())
@@ -396,7 +364,7 @@ class AccountCredentialsServiceImplTest {
         final String newPassword = "new_password";
 
         final AccountBO accountBO = AccountBO.builder()
-                .id("account")
+                .id(1)
                 .addIdentifiers(UserIdentifierBO.builder()
                         .identifier(identifier)
                         .build())
@@ -432,7 +400,7 @@ class AccountCredentialsServiceImplTest {
         final String newPassword = "bad";
 
         final AccountBO accountBO = AccountBO.builder()
-                .id("account")
+                .id(1)
                 .addIdentifiers(UserIdentifierBO.builder()
                         .identifier(identifier)
                         .build())
@@ -463,7 +431,7 @@ class AccountCredentialsServiceImplTest {
 
     @Test
     void replaceIdentifier() {
-        final String accountId = "account";
+        final long accountId = 1;
 
         final AccountBO accountBO = AccountBO.builder()
                 .id(accountId)
@@ -504,7 +472,7 @@ class AccountCredentialsServiceImplTest {
 
     @Test
     void replaceIdentifierNoCredentials() {
-        final String accountId = "account";
+        final long accountId = 1;
 
         assertThatThrownBy(() -> accountCredentialsService.replaceIdentifier(accountId, "username", null))
                 .isInstanceOf(ServiceNotFoundException.class);
@@ -512,7 +480,7 @@ class AccountCredentialsServiceImplTest {
 
     @Test
     void replaceIdentifierNoIdentifier() {
-        final String accountId = "account";
+        final long accountId = 1;
 
         final AccountBO accountBO = AccountBO.builder()
                 .id(accountId)

--- a/service/src/test/java/com/nexblocks/authguard/service/impl/AccountLocksServiceImplTest.java
+++ b/service/src/test/java/com/nexblocks/authguard/service/impl/AccountLocksServiceImplTest.java
@@ -34,23 +34,23 @@ class AccountLocksServiceImplTest {
     void getActiveLocksByAccountId() {
         final Instant now = Instant.now();
 
-        Mockito.when(repository.findByAccountId("account"))
+        Mockito.when(repository.findByAccountId(101))
                 .thenReturn(CompletableFuture.completedFuture(
                         Arrays.asList(
                                 AccountLockDO.builder()
-                                        .accountId("account")
+                                        .accountId(101)
                                         .expiresAt(now.plus(Duration.ofMinutes(5)))
                                         .build(),
                                 AccountLockDO.builder()
-                                        .accountId("account")
+                                        .accountId(101)
                                         .expiresAt(now.minus(Duration.ofMinutes(1)))
                                         .build()
                         )
                 ));
 
-        final Collection<AccountLockBO> actual = service.getActiveLocksByAccountId("account");
+        final Collection<AccountLockBO> actual = service.getActiveLocksByAccountId(101);
         final Collection<AccountLockBO> expected = Collections.singletonList(AccountLockBO.builder()
-                .accountId("account")
+                .accountId(101L)
                 .expiresAt(now.plus(Duration.ofMinutes(5)))
                 .build());
 
@@ -61,17 +61,17 @@ class AccountLocksServiceImplTest {
     void delete() {
         final Instant now = Instant.now();
 
-        Mockito.when(repository.delete("lock"))
+        Mockito.when(repository.delete(1))
                 .thenReturn(CompletableFuture.completedFuture(
                         Optional.of(AccountLockDO.builder()
-                                .accountId("account")
+                                .accountId(101)
                                 .expiresAt(now.plus(Duration.ofMinutes(5)))
                                 .build())
                 ));
 
-        final Optional<AccountLockBO> actual = service.delete("lock");
+        final Optional<AccountLockBO> actual = service.delete(1);
         final AccountLockBO expected = AccountLockBO.builder()
-                .accountId("account")
+                .accountId(101L)
                 .expiresAt(now.plus(Duration.ofMinutes(5)))
                 .build();
 

--- a/service/src/test/java/com/nexblocks/authguard/service/impl/ActionTokenServiceImplTest.java
+++ b/service/src/test/java/com/nexblocks/authguard/service/impl/ActionTokenServiceImplTest.java
@@ -52,16 +52,16 @@ class ActionTokenServiceImplTest {
     @Test
     void generateOtp() {
         final AccountBO accountBO = AccountBO.builder()
-                .id("account")
+                .id(101)
                 .build();
         final AuthResponseBO otpResponse = AuthResponseBO.builder()
                 .token("password-id")
                 .build();
 
-        Mockito.when(accountsService.getById("account")).thenReturn(Optional.of(accountBO));
+        Mockito.when(accountsService.getById(101)).thenReturn(Optional.of(accountBO));
         Mockito.when(otpProvider.generateToken(accountBO)).thenReturn(otpResponse);
 
-        final Try<AuthResponseBO> response = actionTokenService.generateOtp("account");
+        final Try<AuthResponseBO> response = actionTokenService.generateOtp(101);
 
         assertThat(response.isSuccess()).isTrue();
         assertThat(response.get()).isEqualTo(otpResponse);
@@ -74,7 +74,7 @@ class ActionTokenServiceImplTest {
                 .password("password")
                 .build();
         final AccountBO account = AccountBO.builder()
-                .id("account")
+                .id(101)
                 .build();
 
         Mockito.when(basicAuthProvider.getAccount(authRequest)).thenReturn(Either.right(account));
@@ -95,17 +95,17 @@ class ActionTokenServiceImplTest {
     @Test
     void generateFromOtp() {
         final AccountBO account = AccountBO.builder()
-                .id("account")
+                .id(101)
                 .build();
 
-        final String otpToken = "password-id:otp";
+        final String otpToken = "1:otp";
 
         Mockito.when(otpVerifier.verifyAccountToken(otpToken)).thenReturn(Either.right(account.getId()));
-        Mockito.when(accountsService.getById("account")).thenReturn(Optional.of(account));
+        Mockito.when(accountsService.getById(101)).thenReturn(Optional.of(account));
         Mockito.when(accountTokensRepository.save(Mockito.any()))
                 .thenAnswer(invocation -> CompletableFuture.completedFuture(invocation.getArgument(0, AccountTokenDO.class)));
 
-        final Try<ActionTokenBO> actual = actionTokenService.generateFromOtp("password-id", "otp", "something");
+        final Try<ActionTokenBO> actual = actionTokenService.generateFromOtp(1, "otp", "something");
         final ActionTokenBO expected = ActionTokenBO.builder()
                 .accountId(account.getId())
                 .validFor(Duration.ofMinutes(5).toSeconds())

--- a/service/src/test/java/com/nexblocks/authguard/service/impl/ApiKeysServiceImplTest.java
+++ b/service/src/test/java/com/nexblocks/authguard/service/impl/ApiKeysServiceImplTest.java
@@ -65,13 +65,13 @@ class ApiKeysServiceImplTest {
         }
 
         @Override
-        public CompletableFuture<Optional<String>> verifyAndGetAppId(final String apiKey) {
-            return CompletableFuture.completedFuture(Optional.of("app"));
+        public CompletableFuture<Optional<Long>> verifyAndGetAppId(final String apiKey) {
+            return CompletableFuture.completedFuture(Optional.of(1L));
         }
 
         @Override
-        public CompletableFuture<Optional<String>> verifyAndGetClientId(String apiKey) {
-            return CompletableFuture.completedFuture(Optional.of("client"));
+        public CompletableFuture<Optional<Long>> verifyAndGetClientId(String apiKey) {
+            return CompletableFuture.completedFuture(Optional.of(2L));
         }
     }
 
@@ -102,7 +102,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void generateApiKeyWithoutExpiration() {
-        final String appId = "app";
+        final long appId = 1;
         final String key = "key";
         final AppBO app = AppBO.builder()
                 .id(appId)
@@ -142,7 +142,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void generateApiKeyWithExpiration() {
-        final String appId = "app";
+        final long appId = 1;
         final String key = "key";
         final AppBO app = AppBO.builder()
                 .id(appId)
@@ -185,7 +185,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void generateApiKeyNonExistingApp() {
-        final String appId = "app";
+        final long appId = 1;
 
         Mockito.when(applicationsService.getById(appId))
                 .thenReturn(Optional.empty());
@@ -196,7 +196,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void generateApiKeyInvalidType() {
-        final String appId = "app";
+        final long appId = 1;
 
         assertThatThrownBy(() -> apiKeysService.generateApiKey(appId, "none", Duration.ZERO))
                 .isInstanceOf(ServiceException.class);
@@ -204,7 +204,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void getByAppId() {
-        final String appId = "app";
+        final long appId = 1;
         final String key = "key";
         final ApiKeyBO apiKeyBO = ApiKeyBO.builder()
                 .appId(appId)
@@ -222,7 +222,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void validateApiKey() {
-        final String appId = "app";
+        final long appId = 1;
         final String key = "key";
         final AppBO app = AppBO.builder()
                 .id(appId)
@@ -241,7 +241,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void generateClientApiKeyWithoutExpiration() {
-        final String clientId = "client";
+        final long clientId = 2;
         final String key = "key";
         final ClientBO app = ClientBO.builder()
                 .id(clientId)
@@ -281,7 +281,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void generateClientApiKeyWithExpiration() {
-        final String clientId = "client";
+        final long clientId = 2;
         final String key = "key";
         final ClientBO client = ClientBO.builder()
                 .id(clientId)
@@ -324,7 +324,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void generateClientApiKeyNonExistingApp() {
-        final String clientId = "client";
+        final long clientId = 2;
 
         Mockito.when(clientsService.getById(clientId))
                 .thenReturn(Optional.empty());
@@ -335,7 +335,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void generateClientApiKeyInvalidType() {
-        final String clientId = "client";
+        final long clientId = 1;
 
         assertThatThrownBy(() -> apiKeysService.generateClientApiKey(clientId, "none", Duration.ZERO))
                 .isInstanceOf(ServiceException.class);
@@ -343,7 +343,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void validateClientApiKey() {
-        final String clientId = "client";
+        final long clientId = 2;
         final String key = "key";
         final ClientBO client = ClientBO.builder()
                 .id(clientId)
@@ -362,7 +362,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void getById() {
-        final String id = "api_key";
+        final long id = 3;
         final ApiKeyBO apiKeyBO = ApiKeyBO.builder()
                 .id(id)
                 .build();
@@ -380,7 +380,7 @@ class ApiKeysServiceImplTest {
 
     @Test
     void delete() {
-        final String id = "api_key";
+        final long id = 3;
         final ApiKeyBO apiKeyBO = ApiKeyBO.builder()
                 .id(id)
                 .build();

--- a/service/src/test/java/com/nexblocks/authguard/service/impl/ApplicationsServiceImplTest.java
+++ b/service/src/test/java/com/nexblocks/authguard/service/impl/ApplicationsServiceImplTest.java
@@ -89,10 +89,10 @@ class ApplicationsServiceImplTest {
         final AppBO app = random.nextObject(AppBO.class)
                 .withDeleted(false);
 
-        Mockito.when(applicationsRepository.getById(any()))
+        Mockito.when(applicationsRepository.getById(Mockito.anyLong()))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(serviceMapper.toDO(app))));
 
-        final Optional<AppBO> retrieved = applicationsService.getById("");
+        final Optional<AppBO> retrieved = applicationsService.getById(1);
         final List<PermissionBO> expectedPermissions = app.getPermissions().stream()
                 .map(permission -> permission.withEntityType(null))
                 .collect(Collectors.toList());

--- a/service/src/test/java/com/nexblocks/authguard/service/impl/ExchangeAttemptsServiceImplTest.java
+++ b/service/src/test/java/com/nexblocks/authguard/service/impl/ExchangeAttemptsServiceImplTest.java
@@ -34,13 +34,13 @@ class ExchangeAttemptsServiceImplTest {
     @Test
     void findByEntityId() {
         final ExchangeAttemptsQueryBO query = ExchangeAttemptsQueryBO.builder()
-                .entityId("account")
+                .entityId(101L)
                 .build();
 
-        Mockito.when(repository.findByEntity("account"))
+        Mockito.when(repository.findByEntity(101))
                 .thenReturn(CompletableFuture.completedFuture(
                         Collections.singletonList(ExchangeAttemptDO.builder()
-                                .entityId("account")
+                                .entityId(101L)
                                 .exchangeFrom("basic")
                                 .exchangeTo("session")
                                 .build())
@@ -48,7 +48,7 @@ class ExchangeAttemptsServiceImplTest {
 
         final Collection<ExchangeAttemptBO> actual = service.find(query);
         final Collection<ExchangeAttemptBO> expected = Collections.singletonList(ExchangeAttemptBO.builder()
-                .entityId("account")
+                .entityId(101L)
                 .exchangeFrom("basic")
                 .exchangeTo("session")
                 .build());
@@ -60,14 +60,14 @@ class ExchangeAttemptsServiceImplTest {
     void findByEntityIdAndFromTimestamp() {
         final Instant now = Instant.now();
         final ExchangeAttemptsQueryBO query = ExchangeAttemptsQueryBO.builder()
-                .entityId("account")
+                .entityId(101L)
                 .fromTimestamp(now)
                 .build();
 
-        Mockito.when(repository.findByEntityAndTimestamp("account", now))
+        Mockito.when(repository.findByEntityAndTimestamp(101, now))
                 .thenReturn(CompletableFuture.completedFuture(
                         Collections.singletonList(ExchangeAttemptDO.builder()
-                                .entityId("account")
+                                .entityId(101L)
                                 .exchangeFrom("basic")
                                 .exchangeTo("session")
                                 .build())
@@ -75,7 +75,7 @@ class ExchangeAttemptsServiceImplTest {
 
         final Collection<ExchangeAttemptBO> actual = service.find(query);
         final Collection<ExchangeAttemptBO> expected = Collections.singletonList(ExchangeAttemptBO.builder()
-                .entityId("account")
+                .entityId(101L)
                 .exchangeFrom("basic")
                 .exchangeTo("session")
                 .build());
@@ -87,15 +87,15 @@ class ExchangeAttemptsServiceImplTest {
     void findByEntityIdAndFromTimestampAndExchange() {
         final Instant now = Instant.now();
         final ExchangeAttemptsQueryBO query = ExchangeAttemptsQueryBO.builder()
-                .entityId("account")
+                .entityId(101L)
                 .fromTimestamp(now)
                 .fromExchange("basic")
                 .build();
 
-        Mockito.when(repository.findByEntityAndTimestampAndExchange("account", now, "basic"))
+        Mockito.when(repository.findByEntityAndTimestampAndExchange(101, now, "basic"))
                 .thenReturn(CompletableFuture.completedFuture(
                         Collections.singletonList(ExchangeAttemptDO.builder()
-                                .entityId("account")
+                                .entityId(101L)
                                 .exchangeFrom("basic")
                                 .exchangeTo("session")
                                 .build())
@@ -103,7 +103,7 @@ class ExchangeAttemptsServiceImplTest {
 
         final Collection<ExchangeAttemptBO> actual = service.find(query);
         final Collection<ExchangeAttemptBO> expected = Collections.singletonList(ExchangeAttemptBO.builder()
-                .entityId("account")
+                .entityId(101L)
                 .exchangeFrom("basic")
                 .exchangeTo("session")
                 .build());

--- a/service/src/test/java/com/nexblocks/authguard/service/impl/ExchangeServiceImplTest.java
+++ b/service/src/test/java/com/nexblocks/authguard/service/impl/ExchangeServiceImplTest.java
@@ -29,7 +29,7 @@ class ExchangeServiceImplTest {
                     .token(request.getToken())
                     .type("Basic")
                     .entityType(EntityType.ACCOUNT)
-                    .entityId("account")
+                    .entityId(101)
                     .build());
         }
     }
@@ -54,7 +54,7 @@ class ExchangeServiceImplTest {
         @Override
         public Either<Exception, AuthResponseBO> exchange(final AuthRequestBO request) {
             return Either.left(new ServiceAuthorizationException(ErrorCode.GENERIC_AUTH_FAILURE, "Empty",
-                    EntityType.ACCOUNT, "account"));
+                    EntityType.ACCOUNT, 101));
         }
     }
 
@@ -86,7 +86,7 @@ class ExchangeServiceImplTest {
                 .type("Basic")
                 .token(basic)
                 .entityType(EntityType.ACCOUNT)
-                .entityId("account")
+                .entityId(101)
                 .build();
 
         Assertions.assertThat(exchangeService.exchange(authRequest, "basic", "basic", requestContext))
@@ -96,7 +96,7 @@ class ExchangeServiceImplTest {
                 .successful(true)
                 .exchangeFrom("basic")
                 .exchangeTo("basic")
-                .entityId("account")
+                .entityId(101L)
                 .clientId("client")
                 .sourceIp("10.0.0.2")
                 .deviceId("user-device")
@@ -174,7 +174,7 @@ class ExchangeServiceImplTest {
                 .successful(false)
                 .exchangeFrom("basic")
                 .exchangeTo("exception")
-                .entityId("account")
+                .entityId(101L)
                 .build());
 
         Mockito.verify(emb).publish(Mockito.eq(ExchangeServiceImpl.CHANNEL), Mockito.any());
@@ -210,7 +210,7 @@ class ExchangeServiceImplTest {
                 .type("Basic")
                 .token(basic)
                 .entityType(EntityType.ACCOUNT)
-                .entityId("account")
+                .entityId(101)
                 .build();
 
         Assertions.assertThat(exchangeService.exchange(authRequest, "basic", "basic", requestContext))
@@ -220,7 +220,7 @@ class ExchangeServiceImplTest {
                 .successful(true)
                 .exchangeFrom("basic")
                 .exchangeTo("basic")
-                .entityId("account")
+                .entityId(101L)
                 .clientId("client")
                 .sourceIp("10.0.0.3")
                 .deviceId("user-device")

--- a/service/src/test/java/com/nexblocks/authguard/service/impl/IdempotencyServiceImplTest.java
+++ b/service/src/test/java/com/nexblocks/authguard/service/impl/IdempotencyServiceImplTest.java
@@ -26,16 +26,16 @@ class IdempotencyServiceImplTest {
     private IdempotencyService service;
 
     static class TestEntity implements Entity {
-        private final String id;
+        private final long id;
         private final Instant now;
 
-        TestEntity(final String id) {
+        TestEntity(final long id) {
             this.id = id;
             this.now = Instant.now();
         }
 
         @Override
-        public String getId() {
+        public long getId() {
             return id;
         }
 
@@ -65,7 +65,7 @@ class IdempotencyServiceImplTest {
     @Test
     void perform() throws InterruptedException {
         final String idempotentKey = UUID.randomUUID().toString();
-        final TestEntity entity = new TestEntity("entity-id");
+        final TestEntity entity = new TestEntity(1);
         final Supplier<TestEntity> operation = () -> entity;
 
         Mockito.when(repository.findByKeyAndEntityType(idempotentKey, ENTITY_TYPE))
@@ -90,7 +90,7 @@ class IdempotencyServiceImplTest {
     @Test
     void performExistingKey() {
         final String idempotentKey = UUID.randomUUID().toString();
-        final TestEntity entity = new TestEntity("entity-id");
+        final TestEntity entity = new TestEntity(2);
 
         final IdempotentRecordDO idempotentRecord = IdempotentRecordDO.builder()
                 .idempotentKey(idempotentKey)

--- a/service/src/test/java/com/nexblocks/authguard/service/impl/PermissionsServiceImplTest.java
+++ b/service/src/test/java/com/nexblocks/authguard/service/impl/PermissionsServiceImplTest.java
@@ -76,13 +76,13 @@ class PermissionsServiceImplTest {
     @Test
     void getById() {
         final PermissionDO permission = PermissionDO.builder()
-                .id("permission")
+                .id(1)
                 .group("test")
                 .name("read")
                 .build();
 
         final PermissionBO expected = PermissionBO.builder()
-                .id("permission")
+                .id(1)
                 .group("test")
                 .name("read")
                 .build();
@@ -144,13 +144,13 @@ class PermissionsServiceImplTest {
     @Test
     void delete() {
         final PermissionDO permission = PermissionDO.builder()
-                .id("permission")
+                .id(1)
                 .group("test")
                 .name("read")
                 .build();
 
         final PermissionBO expected = PermissionBO.builder()
-                .id("permission")
+                .id(1)
                 .group("test")
                 .name("read")
                 .build();

--- a/service/src/test/java/com/nexblocks/authguard/service/impl/SessionsServiceImplTest.java
+++ b/service/src/test/java/com/nexblocks/authguard/service/impl/SessionsServiceImplTest.java
@@ -38,7 +38,7 @@ class SessionsServiceImplTest {
     @Test
     void create() {
         final SessionBO sessionBO = SessionBO.builder()
-                .accountId("account")
+                .accountId(101)
                 .data(Collections.singletonMap("key", "value"))
                 .build();
 
@@ -57,8 +57,8 @@ class SessionsServiceImplTest {
     @Test
     void getById() {
         final SessionDO sessionDO = SessionDO.builder()
-                .id("session-id")
-                .accountId("account")
+                .id(1)
+                .accountId(101)
                 .data(Collections.singletonMap("key", "value"))
                 .build();
 
@@ -74,8 +74,8 @@ class SessionsServiceImplTest {
     @Test
     void getByToken() {
         final SessionDO sessionDO = SessionDO.builder()
-                .id("session-id")
-                .accountId("account")
+                .id(1)
+                .accountId(101)
                 .sessionToken("token")
                 .data(Collections.singletonMap("key", "value"))
                 .build();
@@ -92,8 +92,8 @@ class SessionsServiceImplTest {
     @Test
     void deleteByToken() {
         final SessionDO sessionDO = SessionDO.builder()
-                .id("session-id")
-                .accountId("account")
+                .id(1)
+                .accountId(101)
                 .sessionToken("token")
                 .data(Collections.singletonMap("key", "value"))
                 .build();

--- a/service/src/test/java/com/nexblocks/authguard/service/impl/VerificationServiceImplTest.java
+++ b/service/src/test/java/com/nexblocks/authguard/service/impl/VerificationServiceImplTest.java
@@ -49,7 +49,7 @@ class VerificationServiceImplTest {
     @Test
     void verifyEmail() {
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .email(AccountEmailBO.builder()
                         .email("to-verify@test.com")
                         .verified(false)
@@ -60,12 +60,12 @@ class VerificationServiceImplTest {
                         .build())
                 .build();
 
-        Mockito.when(accountsService.getById("account-id"))
+        Mockito.when(accountsService.getById(101))
                 .thenReturn(Optional.of(account));
 
         Mockito.when(accountTokensRepository.getByToken("verification-token"))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(AccountTokenDO.builder()
-                        .associatedAccountId("account-id")
+                        .associatedAccountId(101)
                         .expiresAt(Instant.now().plusSeconds(2))
                                 .additionalInformation(ImmutableMap.of("email", "to-verify@test.com"))
                         .build())));
@@ -84,7 +84,7 @@ class VerificationServiceImplTest {
     @Test
     void verifyEmailWrongEmail() {
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .email(AccountEmailBO.builder()
                         .email("to-verify@test.com")
                         .verified(false)
@@ -95,12 +95,12 @@ class VerificationServiceImplTest {
                         .build())
                 .build();
 
-        Mockito.when(accountsService.getById("account-id"))
+        Mockito.when(accountsService.getById(101))
                 .thenReturn(Optional.of(account));
 
         Mockito.when(accountTokensRepository.getByToken("verification-token"))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(AccountTokenDO.builder()
-                        .associatedAccountId("account-id")
+                        .associatedAccountId(101)
                         .expiresAt(Instant.now().plusSeconds(2))
                         .additionalInformation(ImmutableMap.of("email", "wrong@test.com"))
                         .build())));
@@ -112,7 +112,7 @@ class VerificationServiceImplTest {
     @Test
     void verifyEmailNoEmail() {
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .email(AccountEmailBO.builder()
                         .email("to-verify@test.com")
                         .verified(false)
@@ -123,12 +123,12 @@ class VerificationServiceImplTest {
                         .build())
                 .build();
 
-        Mockito.when(accountsService.getById("account-id"))
+        Mockito.when(accountsService.getById(101))
                 .thenReturn(Optional.of(account));
 
         Mockito.when(accountTokensRepository.getByToken("verification-token"))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(AccountTokenDO.builder()
-                        .associatedAccountId("account-id")
+                        .associatedAccountId(101)
                         .expiresAt(Instant.now().plusSeconds(2))
                         .build())));
 
@@ -139,7 +139,7 @@ class VerificationServiceImplTest {
     @Test
     void verifyEmailExpiredToken() {
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .email(AccountEmailBO.builder()
                         .email("to-verify@test.com")
                         .verified(false)
@@ -150,12 +150,12 @@ class VerificationServiceImplTest {
                         .build())
                 .build();
 
-        Mockito.when(accountsService.getById("account-id"))
+        Mockito.when(accountsService.getById(101))
                 .thenReturn(Optional.of(account));
 
         Mockito.when(accountTokensRepository.getByToken("verification-token"))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(AccountTokenDO.builder()
-                        .associatedAccountId("account-id")
+                        .associatedAccountId(101)
                         .expiresAt(Instant.now().minusSeconds(2))
                         .additionalInformation(ImmutableMap.of("email", "wrong@test.com"))
                         .build())));
@@ -167,7 +167,7 @@ class VerificationServiceImplTest {
     @Test
     void sendPhoneNumberVerification() {
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .phoneNumber(PhoneNumberBO.builder()
                         .number("33334444")
                         .verified(false)
@@ -179,13 +179,13 @@ class VerificationServiceImplTest {
                 .token("123456")
                 .build();
 
-        Mockito.when(accountsService.getById("account-id"))
+        Mockito.when(accountsService.getById(101))
                 .thenReturn(Optional.of(account));
 
         Mockito.when(otpProvider.generateToken(account))
                 .thenReturn(otp);
 
-        final AuthResponseBO actual = verificationService.sendPhoneNumberVerification("account-id");
+        final AuthResponseBO actual = verificationService.sendPhoneNumberVerification(101);
 
         assertThat(actual).isEqualTo(otp);
     }
@@ -193,7 +193,7 @@ class VerificationServiceImplTest {
     @Test
     void sendPhoneNumberVerificationByIdentifier() {
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .phoneNumber(PhoneNumberBO.builder()
                         .number("33334444")
                         .verified(false)
@@ -219,68 +219,68 @@ class VerificationServiceImplTest {
     @Test
     void verifyPhoneNumber() {
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .phoneNumber(PhoneNumberBO.builder()
                         .number("33334444")
                         .verified(false)
                         .build())
                 .build();
 
-        Mockito.when(accountsService.getById("account-id"))
+        Mockito.when(accountsService.getById(101))
                 .thenReturn(Optional.of(account));
 
-        Mockito.when(otpVerifier.verifyAccountToken("otp-id:123456"))
-                .thenReturn(Either.right("account-id"));
+        Mockito.when(otpVerifier.verifyAccountToken("1:123456"))
+                .thenReturn(Either.right(101L));
 
         // TODO account argument captor
-        verificationService.verifyPhoneNumber("otp-id", "123456", "33334444");
+        verificationService.verifyPhoneNumber(1, "123456", "33334444");
     }
 
     @Test
     void verifyPhoneNumberWrongNumber() {
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .phoneNumber(PhoneNumberBO.builder()
                         .number("33334444")
                         .verified(false)
                         .build())
                 .build();
 
-        Mockito.when(accountsService.getById("account-id"))
+        Mockito.when(accountsService.getById(101))
                 .thenReturn(Optional.of(account));
 
-        Mockito.when(otpVerifier.verifyAccountToken("otp-id:123456"))
-                .thenReturn(Either.right("account-id"));
+        Mockito.when(otpVerifier.verifyAccountToken("1:123456"))
+                .thenReturn(Either.right(101L));
 
-        assertThatThrownBy(() -> verificationService.verifyPhoneNumber("otp-id", "123456", "9999999"))
+        assertThatThrownBy(() -> verificationService.verifyPhoneNumber(1, "123456", "9999999"))
                 .isInstanceOf(ServiceException.class);
     }
 
     @Test
     void verifyPhoneNumberNullNumber() {
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .build();
 
-        Mockito.when(accountsService.getById("account-id"))
+        Mockito.when(accountsService.getById(101))
                 .thenReturn(Optional.of(account));
 
-        Mockito.when(otpVerifier.verifyAccountToken("otp-id:123456"))
-                .thenReturn(Either.right("account-id"));
+        Mockito.when(otpVerifier.verifyAccountToken("1:123456"))
+                .thenReturn(Either.right(101L));
 
-        assertThatThrownBy(() -> verificationService.verifyPhoneNumber("otp-id", "123456", "9999999"))
+        assertThatThrownBy(() -> verificationService.verifyPhoneNumber(1, "123456", "9999999"))
                 .isInstanceOf(ServiceException.class);
     }
 
     @Test
     void verifyPhoneNumberNonExistingAccount() {
-        Mockito.when(accountsService.getById("account-id"))
+        Mockito.when(accountsService.getById(101))
                 .thenReturn(Optional.empty());
 
-        Mockito.when(otpVerifier.verifyAccountToken("otp-id:123456"))
-                .thenReturn(Either.right("account-id"));
+        Mockito.when(otpVerifier.verifyAccountToken("1:123456"))
+                .thenReturn(Either.right(101L));
 
-        assertThatThrownBy(() -> verificationService.verifyPhoneNumber("otp-id", "123456", "9999999"))
+        assertThatThrownBy(() -> verificationService.verifyPhoneNumber(1, "123456", "9999999"))
                 .isInstanceOf(ServiceException.class);
     }
 }

--- a/sessions/src/main/java/com/nexblocks/authguard/sessions/SessionProvider.java
+++ b/sessions/src/main/java/com/nexblocks/authguard/sessions/SessionProvider.java
@@ -49,7 +49,7 @@ public class SessionProvider implements AuthProvider {
 
         final Map<String, String> data = new HashMap<>();
 
-        data.put(SessionKeys.ACCOUNT_ID, account.getId());
+        data.put(SessionKeys.ACCOUNT_ID, "" + account.getId());
         data.put(SessionKeys.ROLES, String.join(",", account.getRoles()));
         data.put(SessionKeys.PERMISSIONS, account.getPermissions().stream()
                         .map(Permission::getFullName)

--- a/sessions/src/main/java/com/nexblocks/authguard/sessions/SessionVerifier.java
+++ b/sessions/src/main/java/com/nexblocks/authguard/sessions/SessionVerifier.java
@@ -20,13 +20,13 @@ public class SessionVerifier implements AuthVerifier {
     }
 
     @Override
-    public Either<Exception, String> verifyAccountToken(final String sessionToken) {
+    public Either<Exception, Long> verifyAccountToken(final String sessionToken) {
         return sessionsService.getByToken(sessionToken)
                 .map(this::verifySession)
                 .orElseGet(() -> Either.left(new ServiceAuthorizationException(ErrorCode.INVALID_TOKEN, "Invalid session token")));
     }
 
-    private Either<Exception, String> verifySession(final SessionBO session) {
+    private Either<Exception, Long> verifySession(final SessionBO session) {
         if (session.getExpiresAt().isBefore(Instant.now())) {
             return Either.left(new ServiceAuthorizationException(ErrorCode.EXPIRED_TOKEN, "Session has expired",
                     EntityType.ACCOUNT, session.getAccountId()));

--- a/sessions/src/main/java/com/nexblocks/authguard/sessions/exchange/OtpToSession.java
+++ b/sessions/src/main/java/com/nexblocks/authguard/sessions/exchange/OtpToSession.java
@@ -39,7 +39,7 @@ public class OtpToSession implements Exchange {
                 .map(account -> sessionProvider.generateToken(account, options));
     }
 
-    private Either<Exception, AccountBO> getAccount(final String accountId) {
+    private Either<Exception, AccountBO> getAccount(final long accountId) {
         return accountsService.getById(accountId)
                 .<Either<Exception, AccountBO>>map(Either::right)
                 .orElseGet(() -> Either.left(new ServiceAuthorizationException(ErrorCode.ACCOUNT_DOES_NOT_EXIST,

--- a/sessions/src/main/java/com/nexblocks/authguard/sessions/exchange/PasswordlessToSession.java
+++ b/sessions/src/main/java/com/nexblocks/authguard/sessions/exchange/PasswordlessToSession.java
@@ -40,7 +40,7 @@ public class PasswordlessToSession implements Exchange {
                 .map(account -> sessionProvider.generateToken(account, options));
     }
 
-    private Either<Exception, AccountBO> getAccount(final String accountId) {
+    private Either<Exception, AccountBO> getAccount(final long accountId) {
         return accountsService.getById(accountId)
                 .<Either<Exception, AccountBO>>map(Either::right)
                 .orElseGet(() -> Either.left(new ServiceAuthorizationException(ErrorCode.ACCOUNT_DOES_NOT_EXIST,

--- a/sessions/src/test/java/com/nexblocks/authguard/sessions/SessionProviderTest.java
+++ b/sessions/src/test/java/com/nexblocks/authguard/sessions/SessionProviderTest.java
@@ -37,7 +37,7 @@ class SessionProviderTest {
         final SessionProvider sessionProvider = new SessionProvider(sessionsService, sessionsConfig());
 
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .build();
 
         final AuthResponseBO expected = AuthResponseBO.builder()
@@ -63,7 +63,7 @@ class SessionProviderTest {
         final SessionProvider sessionProvider = new SessionProvider(sessionsService, sessionsConfig());
 
         final AccountBO account = AccountBO.builder()
-                .id("account-id")
+                .id(101)
                 .active(false)
                 .build();
 
@@ -76,7 +76,7 @@ class SessionProviderTest {
         final SessionProvider sessionProvider = new SessionProvider(sessionsService, sessionsConfig());
 
         final String sessionToken = "session-token";
-        final String accountId = "account";
+        final long accountId = 101;
 
         Mockito.when(sessionsService.deleteByToken(sessionToken))
                 .thenReturn(Optional.of(SessionBO.builder()

--- a/sessions/src/test/java/com/nexblocks/authguard/sessions/SessionVerifierTest.java
+++ b/sessions/src/test/java/com/nexblocks/authguard/sessions/SessionVerifierTest.java
@@ -22,16 +22,16 @@ class SessionVerifierTest {
         final SessionVerifier sessionVerifier = new SessionVerifier(sessionsService);
 
         final SessionBO session = SessionBO.builder()
-                .id("session-id")
+                .id(1)
                 .sessionToken("token")
-                .accountId("account-id")
+                .accountId(101)
                 .expiresAt(Instant.now().plus(Duration.ofMinutes(20)))
                 .build();
 
         Mockito.when(sessionsService.getByToken(session.getSessionToken()))
                 .thenReturn(Optional.of(session));
 
-        final Either<Exception, String> accountId = sessionVerifier.verifyAccountToken(session.getSessionToken());
+        final Either<Exception, Long> accountId = sessionVerifier.verifyAccountToken(session.getSessionToken());
 
         assertThat(accountId.get()).isEqualTo(session.getAccountId());
     }
@@ -44,7 +44,7 @@ class SessionVerifierTest {
         Mockito.when(sessionsService.getByToken(any()))
                 .thenReturn(Optional.empty());
 
-        final Either<Exception, String> result = sessionVerifier.verifyAccountToken("invalid");
+        final Either<Exception, Long> result = sessionVerifier.verifyAccountToken("invalid");
 
         assertThat(result.isLeft());
         assertThat(result.getLeft()).isInstanceOf(ServiceAuthorizationException.class);
@@ -56,16 +56,16 @@ class SessionVerifierTest {
         final SessionVerifier sessionVerifier = new SessionVerifier(sessionsService);
 
         final SessionBO session = SessionBO.builder()
-                .id("session-id")
+                .id(1)
                 .sessionToken("token")
-                .accountId("account-id")
+                .accountId(101)
                 .expiresAt(Instant.now().minus(Duration.ofMinutes(20)))
                 .build();
 
         Mockito.when(sessionsService.getByToken(session.getSessionToken()))
                 .thenReturn(Optional.of(session));
 
-        final Either<Exception, String> result = sessionVerifier.verifyAccountToken("session-id");
+        final Either<Exception, Long> result = sessionVerifier.verifyAccountToken("session-id");
 
         assertThat(result.isLeft());
         assertThat(result.getLeft()).isInstanceOf(ServiceAuthorizationException.class);


### PR DESCRIPTION
The IDs were already stored as numbers using a converter for SQL databases, but to simplify things for other drivers, we changed it to be always numbers even internally.